### PR TITLE
Issue #000 fix: Unreachable path of ansible.cfg

### DIFF
--- a/deploy/ansible.cfg
+++ b/deploy/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+remote_tmp = /tmp


### PR DESCRIPTION
Facing Below issue When we running ./sunbird_install.sh

PLAY [Install Ansible Prereqs] ******************************************************************************************************************************************************************************

TASK [raw] **************************************************************************************************************************************************************************************************
changed: [10.0.199.214]

PLAY [Install Docker] ***************************************************************************************************************************************************************************************

TASK [Gathering Facts] **************************************************************************************************************************************************************************************
fatal: [10.0.199.214]: UNREACHABLE! => {"changed": false, "msg": "Authentication or permission failure. In some cases, you may have been able to authenticate and did not have permissions on the target directory. Consider changing the remote temp path in ansible.cfg to a path rooted in \"/tmp\". Failed command was: ( umask 77 && mkdir -p \"` echo $HOME/.ansible/tmp/ansible-tmp-1536057258.99-142388785758000 `\" && echo ansible-tmp-1536057258.99-142388785758000=\"` echo $HOME/.ansible/tmp/ansible-tmp-1536057258.99-142388785758000 `\" ), exited with result 1", "unreachable": true}
	to retry, use: --limit @/home/ubuntu/sunbird-devops/ansible/setup-dockerswarm.retry




