### PR TITLE
updating cassandra default connection host

### DIFF
--- a/deploy/cassandra_restore.py
+++ b/deploy/cassandra_restore.py
@@ -26,7 +26,7 @@ from subprocess import STDOUT, call
 from argparse import ArgumentParser
 
 parser = ArgumentParser(description="Restore cassandra snapshot")
-parser.add_argument("--host", default="127.0.0.1", help="ip address of cassandra instance. \
+parser.add_argument("--host", default="localhost", help="ip address of cassandra instance. \
         Default: 127.0.0.1")
 parser.add_argument("snapshotdir", metavar="snapshotdirectory", help="snapshot directory name or path")
 args = parser.parse_args()


### PR DESCRIPTION
By default, cassandra will reject requests from 127.0.0.1, but localhost will suffice.
Updating that