### PR TITLE
##fixing alert rules configuration for secor process monitoring

### DIFF
--- a/ansible/roles/stack-monitor/templates/alertrules.process
+++ b/ansible/roles/stack-monitor/templates/alertrules.process
@@ -6,7 +6,7 @@ ALERT kafka_process_not_running
       description = "Number of running processes are: {% raw %}{{$value}}{% endraw %}",
   }
 ALERT secor_process_not_running
-  IF namedprocess_namegroup_states{groupname="secor",state="Sleeping"} != 8
+  IF namedprocess_namegroup_states{groupname="secor",state="Sleeping"} != 9
   FOR 1m
   ANNOTATIONS {
       summary = "Secor process is not running",


### PR DESCRIPTION
secor count for monitoring is defined as 8, but 9 secor process is running in secor vm, updated secor monitoring count variable to 9 to avoid false alerts. 

@rjshrjndrn Please review and merge.