### PR TITLE
Issue #000 fix: increasing count of monitoring secor process

### DIFF
--- a/ansible/roles/stack-monitor/templates/alertrules.process
+++ b/ansible/roles/stack-monitor/templates/alertrules.process
@@ -6,7 +6,7 @@ ALERT kafka_process_not_running
       description = "Number of running processes are: {% raw %}{{$value}}{% endraw %}",
   }
 ALERT secor_process_not_running
-  IF namedprocess_namegroup_states{groupname="secor",state="Sleeping"} != 8
+  IF namedprocess_namegroup_states{groupname="secor",state="Sleeping"} != 9
   FOR 1m
   ANNOTATIONS {
       summary = "Secor process is not running",


### PR DESCRIPTION
Before the count of the secor process was 8, now nother secor process added for taking druid backup, so we are increasing the monitoring process count to 9.