### PR TITLE
Issue #000 fix: Security alert

### DIFF
--- a/ansible/roles/keycloak/files/python-keycloak-0.12.0/setup.py
+++ b/ansible/roles/keycloak/files/python-keycloak-0.12.0/setup.py
@@ -12,7 +12,7 @@ setup(
     keywords='keycloak openid',
     description=u'python-keycloak is a Python package providing access to the Keycloak API.',
     packages=['keycloak', 'keycloak.authorization', 'keycloak.tests'],
-    install_requires=['requests==2.18.4', 'httmock==1.2.5', 'python-jose==1.4.0'],
+    install_requires=['requests==2.20.0', 'httmock==1.2.5', 'python-jose==1.4.0'],
     classifiers=[
         'Programming Language :: Python :: 3',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',


### PR DESCRIPTION
Upgrading the package to use patched requests.

CVE-2018-18074
More information
moderate severity
Vulnerable versions: <= 2.19.1
Patched version: 2.20.0

The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.