### PR TITLE
Helm charts for Assessment and Print service

### DIFF
--- a/ansible/roles/stack-sunbird/defaults/main.yml
+++ b/ansible/roles/stack-sunbird/defaults/main.yml
@@ -234,6 +234,7 @@ service_env:
   telemetry: ../../../../ansible/roles/stack-sunbird/templates/sunbird_telemetry-service.env
   userorg: ../../../../ansible/roles/stack-sunbird/templates/sunbird_user-org-service.env
   player: ../../../../ansible/roles/stack-sunbird/templates/sunbird_player.env
+  print: ../../../../ansible/roles/stack-sunbird/templates/sunbird_print-service.env
 
 sunbird_portal_player_cdn_enabled: false 
 

--- a/kubernetes/ansible/roles/sunbird-deploy/tasks/main.yml
+++ b/kubernetes/ansible/roles/sunbird-deploy/tasks/main.yml
@@ -4,33 +4,16 @@
     src: "{{ chart_path }}/values.j2"
     dest: "{{ chart_path }}/values.yaml"
 
-- name: copy env file from swarm role
+- name: copy and template env file from swarm role
   template:
     src: "{{service_env[release_name]}}"
-    dest: "{{role_path}}/templates/{{ release_name }}.env"
+    dest: "{{role_path}}/templates/"
 
-- debug: var=release_name
-  register: output
+- name: create env configmap
+  shell: find "{{role_path}}/templates/" -iname "*.env" -exec /bin/bash -c "ls {}; kubectl create configmap {{ release_name }}-config --from-env-file={} -n {{namespace}} --dry-run -o=yaml | kubectl apply -f - " \;
 
-- name: template vars
-  template:
-    src: "{{ release_name }}.env"
-    dest: "{{role_path}}/templates/{{ release_name }}.env"
-  when: output.release_name != "content"
-
-- name: template content service vars
-  template:
-    src: "{{ release_name }}.env"
-    dest: "{{role_path}}/templates/application.conf"
-  when: output.release_name == "content"
-
-- name: create configmap
-  shell: "kubectl create configmap {{ release_name }}-config --from-env-file={{role_path}}/templates/{{ release_name }}.env -n {{namespace}} --dry-run -o=yaml | kubectl apply -f -"
-  when: output.release_name != "content"
-
-- name: create content configmap
-  shell: "kubectl create configmap {{ release_name }}-config --from-file={{role_path}}/templates/application.conf -n {{namespace}} --dry-run -o=yaml | kubectl apply -f -"
-  when: output.release_name == "content"
+- name: create aplicaton configmap
+  shell: find "{{role_path}}/templates/" -iname "*.conf" -exec /bin/bash -c "ls {}; kubectl create configmap {{ release_name }}-config --from-file={} -n {{namespace}} --dry-run -o=yaml | kubectl apply -f - " \;
 
 - name: helm upgrade
   shell: helm upgrade --install --cleanup-on-fail {{ release_name }} {{ chart_path }} -n {{namespace}}

--- a/kubernetes/helm_charts/core/assessment/.helmignore
+++ b/kubernetes/helm_charts/core/assessment/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/helm_charts/core/assessment/Chart.yaml
+++ b/kubernetes/helm_charts/core/assessment/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: assessment
+version: 0.1.0

--- a/kubernetes/helm_charts/core/assessment/templates/_helpers.tpl
+++ b/kubernetes/helm_charts/core/assessment/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "assessment.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "assessment.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "assessment.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "assessment.labels" -}}
+app.kubernetes.io/name: {{ include "assessment.name" . }}
+helm.sh/chart: {{ include "assessment.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/kubernetes/helm_charts/core/assessment/templates/configmap.yaml
+++ b/kubernetes/helm_charts/core/assessment/templates/configmap.yaml
@@ -1,0 +1,10 @@
+#apiVersion: v1
+#data:
+#  {{- range $key, $val := .Values.assessmentenv }}
+#  {{ $key }}: {{ $val }}
+#  {{- end }}
+#kind: ConfigMap
+#metadata:
+#  creationTimestamp: null
+#  name: {{ .Chart.Name }}-config
+#  namespace: {{ .Values.namespace }}

--- a/kubernetes/helm_charts/core/assessment/templates/deployment.yaml
+++ b/kubernetes/helm_charts/core/assessment/templates/deployment.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+     type: {{ .Values.strategy.type }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+{{- if .Values.imagepullsecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagepullsecrets }}
+{{- end }}
+      volumes:
+        - name: {{ .Chart.Name }}-config
+          configMap:
+            name: {{ .Chart.Name }}-config
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.dockerhub }}/{{ .Values.repository }}:{{ .Values.image_tag }}"
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - containerPort: {{ .Values.network.port }}
+        {{- if .Values.assessment.livenessprobe.enabled }}
+        livenessProbe:
+{{ toYaml .Values.assessment.livenessProbe | indent 10 }}
+        {{- end }}
+        {{- if .Values.assessment.readinessprobe.enabled }}
+        readinessProbe:
+{{ toYaml .Values.assessment.readinessProbe | indent 10 }}
+        {{- end }}
+        volumeMounts:
+          - name: {{ .Chart.Name }}-config
+            mountPath: /home/sunbird/assessment-service-1.0-SNAPSHOT/config/
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-service
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  ports:
+  - name: http-{{ .Chart.Name }}
+    protocol: TCP
+    port: {{ .Values.network.targetport }}
+  selector:
+    app: {{ .Chart.Name }}

--- a/kubernetes/helm_charts/core/assessment/templates/deployment.yaml
+++ b/kubernetes/helm_charts/core/assessment/templates/deployment.yaml
@@ -33,11 +33,11 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
         - containerPort: {{ .Values.network.port }}
-        {{- if .Values.assessment.livenessprobe.enabled }}
+        {{- if .Values.assessment.livenessProbe }}
         livenessProbe:
 {{ toYaml .Values.assessment.livenessProbe | indent 10 }}
         {{- end }}
-        {{- if .Values.assessment.readinessprobe.enabled }}
+        {{- if .Values.assessment.readinessProbe }}
         readinessProbe:
 {{ toYaml .Values.assessment.readinessProbe | indent 10 }}
         {{- end }}
@@ -57,6 +57,6 @@ spec:
   ports:
   - name: http-{{ .Chart.Name }}
     protocol: TCP
-    port: {{ .Values.network.targetport }}
+    port: {{ .Values.network.port }}
   selector:
     app: {{ .Chart.Name }}

--- a/kubernetes/helm_charts/core/assessment/templates/deployment.yaml
+++ b/kubernetes/helm_charts/core/assessment/templates/deployment.yaml
@@ -43,7 +43,8 @@ spec:
         {{- end }}
         volumeMounts:
           - name: {{ .Chart.Name }}-config
-            mountPath: /home/sunbird/assessment-service-1.0-SNAPSHOT/config/
+            mountPath: /home/sunbird/assessment-service-1.0-SNAPSHOT/config/application.conf
+            subPath: assessment-service_application.conf
 
 ---
 apiVersion: v1

--- a/kubernetes/helm_charts/core/assessment/values.j2
+++ b/kubernetes/helm_charts/core/assessment/values.j2
@@ -1,0 +1,49 @@
+#jinja2:lstrip_blocks: True
+
+### Default variable file for assessment-service ###
+
+namespace: {{ namespace }}
+imagepullsecrets: {{ imagepullsecrets }}
+dockerhub: {{ dockerhub }}
+
+replicaCount: {{assessment_replicacount|default(1)}}
+repository: {{assessment_repository|default('assessment-service')}}
+image_tag: {{ image_tag }}
+resources:
+  requests:
+    cpu: {{assessment_cpu_req|default('50m')}}
+    memory: {{assessment_mem_req|default('50Mi')}}
+  limits:
+    cpu: {{assessment_cpu_limit|default('1')}}
+    memory: {{assessment_mem_limit|default('500Mi')}}
+network:
+  port: 9000
+strategy:
+  type: RollingUpdate
+  maxsurge: 1
+  maxunavailable: 0
+
+assessment:
+{% if assessment.readinessProbe is not defined %}
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 9000
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+{% elif assessment.readinessProbe %}
+{{ assessment.readinessProbe | to_nice_yaml }}
+{% endif %}
+{% if assessment.livenessProbe is not defined %}
+  livenessProbe:
+    httpGet:
+      path: /service/health
+      port: 9000
+    initialDelaySeconds: 60
+    periodSeconds: 10
+{% elif assessment.livenessProbe %}
+{{ assessment.livenessProbe | to_nice_yaml }}
+{% endif %}

--- a/kubernetes/helm_charts/core/content/templates/deployment.yaml
+++ b/kubernetes/helm_charts/core/content/templates/deployment.yaml
@@ -46,7 +46,8 @@ spec:
         {{- end }}
         volumeMounts:
           - name: {{ .Chart.Name }}-config
-            mountPath: /home/sunbird/content-service-1.0-SNAPSHOT/config/
+            mountPath: /home/sunbird/content-service-1.0-SNAPSHOT/config/application.conf
+            subPath: content-service_application.conf
 
 ---
 apiVersion: v1

--- a/kubernetes/helm_charts/core/nginx-private-ingress/.helmignore
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/helm_charts/core/nginx-private-ingress/Chart.yaml
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/Chart.yaml
@@ -1,0 +1,21 @@
+apiVersion: v2
+name: private-ingress
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application.
+appVersion: 1.16.0

--- a/kubernetes/helm_charts/core/nginx-private-ingress/templates/_helpers.tpl
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "private-ingress.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "private-ingress.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "private-ingress.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "private-ingress.labels" -}}
+helm.sh/chart: {{ include "private-ingress.chart" . }}
+{{ include "private-ingress.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "private-ingress.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "private-ingress.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "private-ingress.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "private-ingress.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/helm_charts/core/nginx-private-ingress/templates/configMap.yaml
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/templates/configMap.yaml
@@ -1,0 +1,33 @@
+apiVersion: v1
+data:
+  default.conf: |
+    server {
+      listen 80;
+      listen [::]:80;
+
+      location /learner/ {
+        rewrite ^/learner/(.*) /$1 break;
+        proxy_pass http://learner-service:9000;
+      }
+      location /api/ {
+        rewrite ^/api/(.*) /$1 break;
+        proxy_pass http://kong:8000;
+      }
+      location /admin-api/ {
+        rewrite ^/admin-api/(.*) /$1 break;
+        proxy_pass http://kong:8001;
+      }
+      location /content/ {
+        rewrite ^/content/(.*) /$1 break;
+        proxy_pass http://content-service:9000;
+      }
+      location /print/ {
+        rewrite ^/print/(.*) /$1 break;
+        proxy_pass http://print-service:5000;
+      }
+    }
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: private-ingress.conf
+  namespace: {{ .Values.namespace }}

--- a/kubernetes/helm_charts/core/nginx-private-ingress/templates/deployment.yaml
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/templates/deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: private-ingress
+  namespace: {{ .Values.namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: private-ingress
+  template:
+    metadata:
+      labels:
+        app: private-ingress
+    spec:
+      containers:
+      - name: name
+        image: nginx
+        resources:
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        - mountPath: /etc/nginx/conf.d/default.conf
+          name: config-volume
+          subPath: default.conf
+          readOnly: true
+      volumes:
+        - name: config-volume
+          configMap:
+            name: private-ingress.conf
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: private-ingress
+  namespace: dev
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 12000
+    targetPort: 80
+  selector:
+    app: private-ingress

--- a/kubernetes/helm_charts/core/nginx-private-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/values.j2
@@ -1,0 +1,1 @@
+namespace: {{ namespace }}

--- a/kubernetes/helm_charts/core/nginx-private-ingress/values.yaml
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/values.yaml
@@ -1,0 +1,1 @@
+namespace: dev

--- a/kubernetes/helm_charts/core/print/.helmignore
+++ b/kubernetes/helm_charts/core/print/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/kubernetes/helm_charts/core/print/Chart.yaml
+++ b/kubernetes/helm_charts/core/print/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: print
+version: 0.1.0

--- a/kubernetes/helm_charts/core/print/templates/_helpers.tpl
+++ b/kubernetes/helm_charts/core/print/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "print.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "print.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "print.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "print.labels" -}}
+app.kubernetes.io/name: {{ include "print.name" . }}
+helm.sh/chart: {{ include "print.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/kubernetes/helm_charts/core/print/templates/configmap.yaml
+++ b/kubernetes/helm_charts/core/print/templates/configmap.yaml
@@ -1,0 +1,1 @@
+# This file will get replaced at runtime

--- a/kubernetes/helm_charts/core/print/templates/deployment.yaml
+++ b/kubernetes/helm_charts/core/print/templates/deployment.yaml
@@ -33,11 +33,11 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
         - containerPort: {{ .Values.network.port }}
-        {{- if .Values.print.livenessprobe }}
+        {{- if .Values.print.livenessProbe }}
         livenessProbe:
 {{ toYaml .Values.print.livenessProbe | indent 10 }}
         {{- end }}
-        {{- if .Values.print.readinessprobe }}
+        {{- if .Values.print.readinessProbe }}
         readinessProbe:
 {{ toYaml .Values.print.readinessProbe | indent 10 }}
         {{- end }}

--- a/kubernetes/helm_charts/core/print/templates/deployment.yaml
+++ b/kubernetes/helm_charts/core/print/templates/deployment.yaml
@@ -33,11 +33,11 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
         ports:
         - containerPort: {{ .Values.network.port }}
-        {{- if .Values.print.livenessprobe.enabled }}
+        {{- if .Values.print.livenessprobe }}
         livenessProbe:
 {{ toYaml .Values.print.livenessProbe | indent 10 }}
         {{- end }}
-        {{- if .Values.print.readinessprobe.enabled }}
+        {{- if .Values.print.readinessprobe }}
         readinessProbe:
 {{ toYaml .Values.print.readinessProbe | indent 10 }}
         {{- end }}

--- a/kubernetes/helm_charts/core/print/templates/deployment.yaml
+++ b/kubernetes/helm_charts/core/print/templates/deployment.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Values.namespace }}
+  annotations:
+    reloader.stakater.com/auto: "true"
+spec:
+  replicas: {{ .Values.replicaCount }}
+  strategy:
+     type: {{ .Values.strategy.type }}
+  selector:
+    matchLabels:
+      app: {{ .Chart.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Chart.Name }}
+    spec:
+{{- if .Values.imagepullsecrets }}
+      imagePullSecrets:
+      - name: {{ .Values.imagepullsecrets }}
+{{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: "{{ .Values.dockerhub }}/{{ .Values.repository }}:{{ .Values.image_tag }}"
+        imagePullPolicy: Always
+        envFrom:
+        - configMapRef:
+            name: {{ .Chart.Name }}-config
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+        - containerPort: {{ .Values.network.port }}
+        {{- if .Values.print.livenessprobe.enabled }}
+        livenessProbe:
+{{ toYaml .Values.print.livenessProbe | indent 10 }}
+        {{- end }}
+        {{- if .Values.print.readinessprobe.enabled }}
+        readinessProbe:
+{{ toYaml .Values.print.readinessProbe | indent 10 }}
+        {{- end }}
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}-service
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: {{ .Chart.Name }}
+spec:
+  ports:
+  - name: http-{{ .Chart.Name }}
+    protocol: TCP
+    port: {{ .Values.network.port }}
+  selector:
+    app: {{ .Chart.Name }}

--- a/kubernetes/helm_charts/core/print/values.j2
+++ b/kubernetes/helm_charts/core/print/values.j2
@@ -1,3 +1,4 @@
+#jinja2:lstrip_blocks: True
 
 ### Default variable file for print-service ###
 
@@ -23,10 +24,7 @@ strategy:
   maxunavailable: 0
 
 print:
-  readinessprobe:
-    enabled: true
-  livenessprobe:
-    enabled: true
+{% if print.readinessProbe is not defined %}
   readinessProbe:
     httpGet:
       path: /health
@@ -36,9 +34,16 @@ print:
     timeoutSeconds: 5
     failureThreshold: 5
     successThreshold: 1
+{% elif print.readinessProbe %}
+{{ print.readinessProbe | to_nice_yaml }}
+{% endif %}
+{% if print.livenessProbe is not defined %}
   livenessProbe:
     httpGet:
       path: /service/health
       port: 5000
     initialDelaySeconds: 60
     periodSeconds: 10
+{% elif print.livenessProbe %}
+{{ print.livenessProbe | to_yaml }}
+{% endif %}

--- a/kubernetes/helm_charts/core/print/values.j2
+++ b/kubernetes/helm_charts/core/print/values.j2
@@ -1,0 +1,44 @@
+
+### Default variable file for print-service ###
+
+namespace: {{ namespace }}
+imagepullsecrets: {{ imagepullsecrets }}
+dockerhub: {{ dockerhub }}
+
+replicaCount: {{print_replicacount|default(1)}}
+repository: {{print_repository|default('print-service')}}
+image_tag: {{ image_tag }}
+resources:
+  requests:
+    cpu: {{print_cpu_req|default('50m')}}
+    memory: {{print_mem_req|default('50Mi')}}
+  limits:
+    cpu: {{print_cpu_limit|default('1')}}
+    memory: {{print_mem_limit|default('1024Mi')}}
+network:
+  port: 5000
+strategy:
+  type: RollingUpdate
+  maxsurge: 1
+  maxunavailable: 0
+
+print:
+  readinessprobe:
+    enabled: true
+  livenessprobe:
+    enabled: true
+  readinessProbe:
+    httpGet:
+      path: /health
+      port: 5000
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 5
+    successThreshold: 1
+  livenessProbe:
+    httpGet:
+      path: /service/health
+      port: 5000
+    initialDelaySeconds: 60
+    periodSeconds: 10

--- a/kubernetes/helm_charts/networkconfig/templates/private-vs.yaml
+++ b/kubernetes/helm_charts/networkconfig/templates/private-vs.yaml
@@ -105,3 +105,13 @@ spec:
     route:
     - destination:
         host: cert-registry-service
+  - match:
+    - uri:
+        prefix: /print/
+    - uri:
+        prefix: /print
+    rewrite:
+      uri: /
+    route:
+    - destination:
+        host: print-service

--- a/kubernetes/pipelines/deploy_core/Jenkinsfile
+++ b/kubernetes/pipelines/deploy_core/Jenkinsfile
@@ -3,6 +3,7 @@ node() {
     try {
         stage('checkout public repo') {
             checkout scm
+            sh'git clean -fxd'
         }
 
         stage('deploy') {

--- a/kubernetes/pipelines/deploy_core/Jenkinsfile
+++ b/kubernetes/pipelines/deploy_core/Jenkinsfile
@@ -2,7 +2,6 @@
 node() {
     try {
         stage('checkout public repo') {
-            cleanWs()
             checkout scm
         }
 


### PR DESCRIPTION
private vs entry for print service
private helm nginx chart
fix: 
Automated env, conf configmap creation 
No need to have seperate tasks for env and .conf confimap creation