### PR TITLE
Nginx and grafana related changes for k8s

### DIFF
--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-operator.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-operator.yaml
@@ -43,7 +43,7 @@ alertmanager:
         receiver: "{{ item.team }}"
         # Comment to ensure proper indentation while templating
         {% if item.severity_mailing_filter is defined and item.severity_mailing_filter|length %}
-routes:
+      routes:
         {% for filter in item.severity_mailing_filter %}
         # Comment to ensure proper indentation while templating
         - match:

--- a/kubernetes/helm_charts/core/nginx-private-ingress/templates/configmap.yaml
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/templates/configmap.yaml
@@ -5,7 +5,7 @@ data:
       listen 80;
       listen [::]:80;
 
-      resolver {{ kube_dns_ip }};
+      resolver {{ .Values.kube_dns_ip }};
 
       location /learner/ {
         rewrite ^/learner/(.*) /$1 break;

--- a/kubernetes/helm_charts/core/nginx-private-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/values.j2
@@ -1,5 +1,6 @@
 namespace: {{ namespace }}
 nginx_private_ingress_type: {{ nginx_private_ingress_type | default('LoadBalancer') }}
 private_ingress_custom_annotations: {{ private_ingress_custom_annotations | d('false') | lower }}
+kube_dns_ip: {{kube_dns_ip}}
 private_ingress_annotation:
   cloud_provider: 'service.beta.kubernetes.io/azure-load-balancer-internal: "true"'

--- a/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
@@ -62,7 +62,7 @@ proxyconfig: |
     proxy_set_header    X-Forwarded-Proto $scheme;
   
     ignore_invalid_headers off;  #pass through headers from Jenkins which are considered invalid by Nginx server.
-    resolver {{ kube_dns_ip }};
+    resolver {{ kube_dns_ip }} valid=30s;
 
     location ~* ^/auth/realms/(.+)/token/introspect/ {
           return 301 {{proto}}://$host/api/auth/v1/realms/$1/token/introspect;
@@ -83,19 +83,6 @@ proxyconfig: |
       return 301 {{proto}}://$host/api/auth/v1/realms/$1/clients-registrations/;
     }
   
-    location ~* ^/auth/v1/refresh/token  {
-      set $target http://player:3000;
-      rewrite ^/auth/(.*) /auth/$1 break;
-      proxy_pass $target;
-      
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Scheme $scheme;
-      proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
-      proxy_set_header X-Forwarded-Proto $scheme;
-  
-    }
-   
     location ~* ^/auth/admin/master/console/ {
       return 301 {{proto}}://{{ proxy_server_name }};
     }
@@ -110,20 +97,6 @@ proxyconfig: |
       proxy_set_header X-Scheme $scheme;
       proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
-    }
-   location /registry/ {
-      set $target http://registry_registry:8080;
-      rewrite ^/registry/(.*) /$1 break;
-      proxy_pass $target;
-  
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Scheme $scheme;
-      proxy_connect_timeout 1;
-      proxy_send_timeout 30;
-      proxy_read_timeout 40;
-      proxy_set_header    X-Forwarded-Proto $scheme;
-      # root   /usr/share/nginx/www;
     }
     location /api/ {
       if ($request_method = OPTIONS ) {
@@ -191,40 +164,13 @@ proxyconfig: |
       proxy_pass $target;
     }
   
-  
     location /grafana/ {
       rewrite ^/grafana/(.*) /$1 break;
       proxy_pass http://prometheus-operator-grafana.monitoring.svc.cluster.local;
     }
   
-  {% if proxy_prometheus==true %}
-    location /{{prometheus_alertmanager_route_prefix}}/ {
-      set $target http://monitor_alertmanager:9093;
-      rewrite ^/{{prometheus_alertmanager_route_prefix}}/(.*) /{{prometheus_alertmanager_route_prefix}}/$1 break;
-      proxy_pass $target;
-  
-      proxy_set_header Host $host;
-      proxy_set_header X-Real-IP $remote_addr;
-      proxy_set_header X-Scheme $scheme;
-      proxy_connect_timeout 1;
-      proxy_send_timeout 30;
-      proxy_read_timeout 40;
-  
-      auth_basic           "Prometheus Alert manager";
-      auth_basic_user_file /etc/secrets/prom_admin_creds;
-    }
-  
-    location /{{prometheus_route_prefix}}/ {
-      set $target http://monitor_prometheus:9090;
-      rewrite ^/(.*) /$1 break;
-      proxy_pass $target;
-    }
-  {% endif %}
-  
    location /encryption/ {
-      set $target http://encryption-service:8013;
       rewrite ^/encryption/(.*) /$1 break;
-      proxy_pass $target;
   
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
@@ -233,7 +179,7 @@ proxyconfig: |
       proxy_send_timeout 30;
       proxy_read_timeout 40;
       proxy_set_header    X-Forwarded-Proto $scheme;
-      # root   /usr/share/nginx/www;
+      proxy_pass encryption;
     }
   
   
@@ -502,6 +448,7 @@ nginxconfig: |
   http {
       include       /etc/nginx/mime.types;
       default_type  application/octet-stream;
+      resolver {{ kube_dns_ip }} valid=30s;
   
       lua_load_resty_core off;
       log_format  main  '$remote_addr - $remote_user [$time_local] '
@@ -553,6 +500,11 @@ nginxconfig: |
   
       upstream player {
           server player:3000;
+          keepalive 1000;
+      }
+
+      upstream encryption {
+          server encryption-service:8013;
           keepalive 1000;
       }
   
@@ -613,15 +565,13 @@ keycloakconf: |
       return 301 {{proto}}://$host/api/auth/v1/realms/$1/clients-registrations/;
     }
     location ~* ^/auth/v1/refresh/token  {
-      set $target http://player:3000;
       rewrite ^/auth/(.*) /auth/$1 break;
-      proxy_pass $target;
-      
       proxy_set_header Host $host;
       proxy_set_header X-Real-IP $remote_addr;
       proxy_set_header X-Scheme $scheme;
       proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
       proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_pass player;
     }
    
     location ~* ^/auth/admin/master/console/ {


### PR DESCRIPTION
fd2dcbe (Rajesh Rajendran, 7 minutes ago)
   Updating nginx helm values.j2

   1. Deleted registry block, and prometheus 2. Added upstream for services;
   catch is if upstream not deployed
      nginx will crashloop.
      But we'll get better performance 3. Adding resolver, in upstream and
   resolution timeout

d7e577819 (Rajesh Rajendran, 11 days ago)
   Getting kube dns ip

   This is required for nginx to resolve upstreams. But its not an ideal way. 
   Workaround till a helm native way is generated.

95f4a4054 (Rajesh Rajendran, 23 hours ago)
   Optional operation for grafana backup script