### PR TITLE
Making nginx volume mounts optional

### DIFF
--- a/kubernetes/helm_charts/core/nginx-public-ingress/templates/daemonset.yaml
+++ b/kubernetes/helm_charts/core/nginx-public-ingress/templates/daemonset.yaml
@@ -25,17 +25,15 @@ spec:
         - name: tls
           secret:
             secretName: ingress-cert
-{{- if .Values.merge_domain_status }}
-        - name: tls-merge
-          secret:
-            secretName: ingress-merge-cert
-{{- end }}
         - name: proxy-config
           configMap:
             name: proxy-default
         - name: nginx-config
           configMap:
             name: nginx-conf
+{{- if .Values.volumes }}
+{{ toYaml .Values.volumes | indent 8 }}
+{{- end }}
 {{- if .Values.merge_domain_status }}
         - name: nginx-merge-config
           configMap:
@@ -50,11 +48,6 @@ spec:
           - name: tls
             mountPath: /etc/secrets
             readOnly: true
-{{- if .Values.merge_domain_status }}
-          - name: tls-merge
-            mountPath: /etc/secrets-merge
-            readOnly: true
-{{- end }}
           - name: proxy-config
             mountPath: /etc/nginx/conf.d
             readOnly: true
@@ -62,11 +55,8 @@ spec:
             mountPath: /etc/nginx/nginx.conf
             subPath: nginx.conf
             readOnly: true
-{{- if .Values.merge_domain_status }}
-          - name: nginx-merge-config
-            mountPath: /etc/nginx/keycloak.conf
-            subPath: keycloak.conf
-            readOnly: true
+{{- if .Values.volumeMounts }}
+{{ toYaml .Values.volumeMounts | indent 10 }}
 {{- end }}
         ports:
         - containerPort: 80

--- a/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
+++ b/kubernetes/helm_charts/core/nginx-public-ingress/values.j2
@@ -14,6 +14,36 @@ service:
     targetPort: 443
     nodePort: 31390
 
+{% if nginx_volumes is defined and nginx_volumes %}
+{#
+This is for custom nginx volume mount options in common.yaml
+example:
+nginx_volumes:
+  volumes:
+    - name: tls
+      secret:
+        secretName: ingress-cert
+    - name: proxy-config
+      configMap:
+        name: proxy-default
+    - name: nginx-config
+      configMap:
+        name: nginx-conf
+  volumemounts:
+    - name: tls
+      mountPath: /etc/secrets
+      readOnly: true
+    - name: proxy-config
+      mountPath: /etc/nginx/conf.d
+      readOnly: true
+    - name: nginx-config
+      mountPath: /etc/nginx/nginx.conf
+      subPath: nginx.conf
+      readOnly: true
+#}
+volumes: {{ nginx_volumes.volumes | to_json }}
+volumeMounts: {{ nginx_volumes.volumeMounts | to_json }}
+{% endif %}
 
 imagepullsecrets: {{ imagepullsecrets }}
 dockerhub: {{ dockerhub }}


### PR DESCRIPTION
This is to make Nginx volume mounts optional.
ie, if some custom configs or ssls have to be mounted
This variable can be updated. 
Only caveat is if you want to do a volumeMount,
first make sure that the volume is mounted.