### PR TITLE
SC-1671 Onboarding user v3 create API

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -5127,3 +5127,20 @@ kong_apis:
       config.limit_by: credential
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
+
+  - name: createUserVersion3
+    request_path: "{{ user_service_prefix }}/v3/create"
+    upstream_url: "{{ learning_service_url }}/v3/user/create"
+    strip_request_path: true
+    plugins:
+    - name: jwt
+    - name: cors
+    - "{{ statsd_pulgin }}"
+    - name: acl
+      config.whitelist: "{{ createUserVersion3_ACL | default(['userUpdate']) }}"
+    - name: rate-limiting
+      config.policy: local
+      config.hour: "{{ medium_rate_limit_per_hour }}"
+      config.limit_by: credential
+    - name: request-size-limiting
+      config.allowed_payload_size: "{{ small_request_size_limit }}"


### PR DESCRIPTION
**Ticket Ref:** [SC-1671](https://project-sunbird.atlassian.net/browse/SC-1671?filter=10743)
**R2.8.0**
1: `/v3/user/create`(sync ES response) need to be onboarded.