### PR TITLE
SB-18248 Allow mobile client to download the cert

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -3847,6 +3847,23 @@ kong_apis:
       config.limit_by: credential
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
+      
+  - name: downloadCertificate
+    request_path: "{{ user_service_prefix }}/v1/certs/download"
+    upstream_url: "{{ learning_service_url }}/v1/user/certs/download"
+    strip_request_path: true
+    plugins:
+    - name: jwt
+    - name: cors
+    - "{{ statsd_pulgin }}"
+    - name: acl
+      config.whitelist: "{{ downloadCertificate_ACL | default(['publicUser','mobileApis']) }}"
+    - name: rate-limiting
+      config.policy: local
+      config.hour: "{{ medium_rate_limit_per_hour }}"
+      config.limit_by: credential
+    - name: request-size-limiting
+      config.allowed_payload_size: "{{ small_request_size_limit }}"
 
   - name: validateRegCertificate
     request_path: "{{ cert_registry_service_prefix }}/v1/certs/validate"


### PR DESCRIPTION
Adding downloadCert API to kong - this is rolled back from 2.9 branch.