### PR TITLE
SB-18656 - Onboard certreg read and search

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -3932,6 +3932,40 @@ kong_apis:
       config.limit_by: credential
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
+      
+  - name: searchRegCertificate
+    request_path: "{{ cert_registry_service_prefix }}/v1/certs/search"
+    upstream_url: "{{ cert_registry_service_url }}/certs/v1/registry/search"
+    strip_request_path: true
+    plugins:
+    - name: jwt
+    - name: cors
+    - "{{ statsd_pulgin }}"
+    - name: acl
+      config.whitelist: "{{ searchRegCertificate_ACL | default(['publicUser']) }}"
+    - name: rate-limiting
+      config.policy: local
+      config.hour: "{{ medium_rate_limit_per_hour }}"
+      config.limit_by: credential
+    - name: request-size-limiting
+      config.allowed_payload_size: "{{ small_request_size_limit }}"
+
+  - name: readRegCertificate
+    request_path: "{{ cert_registry_service_prefix }}/v1/certs/read"
+    upstream_url: "{{ cert_registry_service_url }}/certs/v1/registry/read"
+    strip_request_path: true
+    plugins:
+    - name: jwt
+    - name: cors
+    - "{{ statsd_pulgin }}"
+    - name: acl
+      config.whitelist: "{{ readRegCertificate_ACL | default(['publicUser']) }}"
+    - name: rate-limiting
+      config.policy: local
+      config.hour: "{{ medium_rate_limit_per_hour }}"
+      config.limit_by: credential
+    - name: request-size-limiting
+      config.allowed_payload_size: "{{ small_request_size_limit }}"
 
   - name: updateDesktopApp
     request_path: "{{ desktop_app_prefix }}/v1/update"


### PR DESCRIPTION
This is required for quiz programmes and these APIs are present in 2.9.0 branch. Rolling back now to 2.8.0