### PR TITLE
liveliness succes threshold changes.

### DIFF
--- a/ansible/roles/stack-sunbird/defaults/main.yml
+++ b/ansible/roles/stack-sunbird/defaults/main.yml
@@ -319,7 +319,7 @@ apimanager_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 assessment_liveness_readiness:
   healthcheck: true
@@ -340,7 +340,7 @@ assessment_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 cert_liveness_readiness:
   healthcheck: true 
@@ -361,7 +361,7 @@ cert_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 certregistry_liveness_readiness:
   healthcheck: true
@@ -382,7 +382,7 @@ certregistry_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 content_liveness_readiness:
   healthcheck: true
@@ -403,7 +403,7 @@ content_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 enc_liveness_readiness:
   healthcheck: true
@@ -424,7 +424,7 @@ enc_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 knowledgemw_liveness_readiness:
   healthcheck: true
@@ -445,7 +445,7 @@ knowledgemw_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 learner_liveness_readiness:
   healthcheck: true
@@ -466,7 +466,7 @@ learner_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 notification_liveness_readiness:
   healthcheck: true
@@ -487,7 +487,7 @@ notification_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 player_liveness_readiness:
   healthcheck: true
@@ -508,7 +508,7 @@ player_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 print_liveness_readiness:
   healthcheck: true 
@@ -529,7 +529,7 @@ print_liveness_readiness:
     periodSeconds: 30
     timeoutSeconds: 10
     failureThreshold: 5
-    successThreshold: 2
+    successThreshold: 1
 
 telemetry_liveness_readiness:
   healthcheck: true


### PR DESCRIPTION
Fix Issue: spec.template.spec.containers[0].livenessProbe.successThreshold: Invalid value: 2: must be 1