### PR TITLE
Monitoring changes

### DIFF
--- a/exporters/Go/kafka-topic-exporter/main.go
+++ b/exporters/Go/kafka-topic-exporter/main.go
@@ -219,7 +219,7 @@ For example,
 	fmt.Println("kafka is accessible")
 	// Initializing kafka
 	kafkaReader = kafka.NewReader(kafka.ReaderConfig{
-		Brokers:          []string{kafkaHost},
+		Brokers:          strings.Split(kafkaHost, ","),
 		GroupID:          "metrics-reader-test", // Consumer group ID
 		Topic:            kafkaTopic,
 		MinBytes:         1e3,  // 1KB


### PR DESCRIPTION
1. Upgraded prom operator to 8.12.3
   No more hacks to make cpu metrics work
   kubelet scrapping via https
2. Upgraded ES exprorter to 3.0
   K8s won't support v1/beta2 for deployment.