### PR TITLE
Redis exporter for multi cluster

### DIFF
--- a/kubernetes/ansible/roles/sunbird-monitoring/defaults/main.yml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/defaults/main.yml
@@ -11,6 +11,7 @@ monitoring_stack:
   - additional-scrape-configs
   - alertrules
   - kafka-topic-exporter
+  - prometheus-redis-exporter
 
 namespace: monitoring
 

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/additional-scrape-configs.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/additional-scrape-configs.yaml
@@ -160,6 +160,18 @@ scrapeconfig:
       replacement: $1
       action: keep
 
+  - job_name: 'redis_exporter_targets'
+    static_configs:
+      - targets: ["{{ groups['redis-exporter-targets'] | difference(["localhost"]) | map('regex_replace', '^(.*)$', '\\1:6379') | list | join("\", \"") }}"]
+    metrics_path: /scrape
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: redis-exporter:9121
+
   {% for item in service_blackbox_checks %}
   # This empty line ensures indentation is correct after ansible jinja2 template is materialized
   - job_name: 'availability_{{ item.service_name }}'

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-redis-exporter.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-redis-exporter.yaml
@@ -1,0 +1,1 @@
+fullnameOverride: redis-exporter

--- a/kubernetes/helm_charts/monitoring/dashboards/dashboards/redis.json
+++ b/kubernetes/helm_charts/monitoring/dashboards/dashboards/redis.json
@@ -12,12 +12,12 @@
       }
     ]
   },
-  "description": "Redis Dashboard for Prometheus Redis Exporter",
+  "description": "Redis Dashboard for Prometheus Redis Exporter 1.x",
   "editable": true,
   "gnetId": 763,
   "graphTooltip": 0,
-  "id": 39,
-  "iteration": 1580881120127,
+  "id": 25,
+  "iteration": 1589262474857,
   "links": [],
   "panels": [
     {
@@ -29,7 +29,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": "Prometheus_Stateful",
+      "datasource": "Prometheus",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -43,7 +43,7 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 6,
+        "w": 2,
         "x": 0,
         "y": 0
       },
@@ -65,6 +65,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -117,7 +118,7 @@
         "rgba(237, 129, 40, 0.89)",
         "rgba(50, 172, 45, 0.97)"
       ],
-      "datasource": "Prometheus_Stateful",
+      "datasource": "Prometheus",
       "decimals": 0,
       "editable": true,
       "error": false,
@@ -131,8 +132,8 @@
       },
       "gridPos": {
         "h": 7,
-        "w": 6,
-        "x": 6,
+        "w": 2,
+        "x": 2,
         "y": 0
       },
       "hideTimeOverride": true,
@@ -154,6 +155,7 @@
       "maxDataPoints": 100,
       "nullPointMode": "connected",
       "nullText": null,
+      "options": {},
       "postfix": "",
       "postfixFontSize": "50%",
       "prefix": "",
@@ -186,7 +188,98 @@
       "thresholds": "",
       "timeFrom": "1m",
       "timeShift": null,
-      "title": "Connected Clients",
+      "title": "Clients",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "Prometheus",
+      "decimals": 0,
+      "editable": true,
+      "error": false,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "hideTimeOverride": true,
+      "id": 11,
+      "interval": null,
+      "isNew": true,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "100 * (redis_memory_used_bytes{instance=~\"$instance\"}  / redis_memory_max_bytes{instance=~\"$instance\"} )",
+          "format": "time_series",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "metric": "",
+          "refId": "A",
+          "step": 2
+        }
+      ],
+      "thresholds": "80,95",
+      "timeFrom": "1m",
+      "timeShift": null,
+      "title": "Memory Usage",
       "type": "singlestat",
       "valueFontSize": "80%",
       "valueMaps": [
@@ -203,18 +296,119 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus_Stateful",
+      "datasource": "Prometheus",
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "isNew": true,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "rate(redis_commands_processed_total{instance=~\"$instance\"}[1m])",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "",
+          "metric": "A",
+          "refId": "A",
+          "step": 240,
+          "target": ""
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Commands Executed / sec",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
       "decimals": 2,
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 7,
-        "w": 12,
-        "x": 12,
+        "w": 8,
+        "x": 16,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 1,
       "isNew": true,
       "legend": {
@@ -230,6 +424,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": true,
       "pointradius": 5,
       "points": false,
@@ -313,10 +510,11 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus_Stateful",
+      "datasource": "Prometheus",
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 7,
@@ -324,6 +522,7 @@
         "x": 0,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 7,
       "isNew": true,
       "legend": {
@@ -341,6 +540,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -417,10 +619,11 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus_Stateful",
+      "datasource": "Prometheus",
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 7,
@@ -428,6 +631,7 @@
         "x": 12,
         "y": 7
       },
+      "hiddenSeries": false,
       "id": 10,
       "isNew": true,
       "legend": {
@@ -443,6 +647,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -517,17 +724,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus_Stateful",
+      "datasource": "Prometheus",
       "editable": true,
       "error": false,
       "fill": 7,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
         "h": 7,
-        "w": 24,
+        "w": 12,
         "x": 0,
         "y": 14
       },
+      "hiddenSeries": false,
       "id": 5,
       "isNew": true,
       "legend": {
@@ -545,6 +754,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -608,6 +820,114 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "editable": true,
+      "error": false,
+      "fill": 7,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "hiddenSeries": false,
+      "id": 13,
+      "isNew": true,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum (redis_db_keys{instance=~\"$instance\"}) - sum (redis_db_keys_expiring{instance=~\"$instance\"}) ",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "not expiring",
+          "refId": "A",
+          "step": 240,
+          "target": ""
+        },
+        {
+          "expr": "sum (redis_db_keys_expiring{instance=~\"$instance\"}) ",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "expiring",
+          "metric": "",
+          "refId": "B",
+          "step": 240
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Expiring vs Not-Expiring Keys",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "aliasColors": {
         "evicts": "#890F02",
         "memcached_items_evicted_total{instance=\"172.17.0.1:9150\",job=\"prometheus\"}": "#890F02",
@@ -616,17 +936,19 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "datasource": "Prometheus_Stateful",
+      "datasource": "Prometheus",
       "editable": true,
       "error": false,
       "fill": 1,
+      "fillGradient": 0,
       "grid": {},
       "gridPos": {
-        "h": 5,
-        "w": 24,
+        "h": 7,
+        "w": 12,
         "x": 0,
         "y": 21
       },
+      "hiddenSeries": false,
       "id": 8,
       "isNew": true,
       "legend": {
@@ -642,6 +964,9 @@
       "linewidth": 2,
       "links": [],
       "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -719,10 +1044,108 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "Prometheus",
+      "editable": true,
+      "error": false,
+      "fill": 8,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 12,
+        "y": 21
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "isNew": true,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk(5, irate(redis_commands_total{instance=~\"$instance\"} [1m]))",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{ cmd }}",
+          "metric": "redis_command_calls_total",
+          "refId": "A",
+          "step": 240
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Command Calls / sec",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 18,
+  "schemaVersion": 21,
   "style": "dark",
   "tags": [
     "prometheus",
@@ -733,24 +1156,27 @@
       {
         "allValue": null,
         "current": {
-          "text": "monitor_stateful_redis-exporter:9121",
-          "value": "monitor_stateful_redis-exporter:9121"
+          "text": "redis://redis-1-headless:6379",
+          "value": "redis://redis-1-headless:6379"
         },
+        "datasource": "Prometheus",
+        "definition": "label_values(redis_up, instance)",
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "instance",
-        "options": [
-          {
-            "selected": true,
-            "text": "monitor_stateful_redis-exporter:9121",
-            "value": "monitor_stateful_redis-exporter:9121"
-          }
-        ],
-        "query": "monitor_stateful_redis-exporter:9121",
+        "options": [],
+        "query": "label_values(redis_up, instance)",
+        "refresh": 2,
+        "regex": "",
         "skipUrlSync": false,
-        "type": "custom"
+        "sort": 1,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -785,6 +1211,6 @@
   },
   "timezone": "browser",
   "title": "Redis Dashboard for Prometheus Redis Exporter",
-  "uid": "8QBoYnaWz",
+  "uid": "A4ZEhMRGk",
   "version": 2
 }

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/.helmignore
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/Chart.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: 1.3.4
+description: Prometheus exporter for Redis metrics
+home: https://github.com/oliver006/redis_exporter
+keywords:
+- prometheus
+- redis
+maintainers:
+- email: arcadie.condrat@gmail.com
+  name: acondrat
+name: prometheus-redis-exporter
+sources:
+- https://github.com/oliver006/redis_exporter
+version: 3.4.0

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/OWNERS
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/OWNERS
@@ -1,0 +1,4 @@
+approvers:
+- acondrat
+reviewers:
+- acondrat

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/README.md
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/README.md
@@ -1,0 +1,135 @@
+# prometheus-redis-exporter
+
+[redis_exporter](https://github.com/oliver006/redis_exporter) is a Prometheus exporter for Redis metrics.
+
+## TL;DR;
+
+```bash
+$ helm install stable/prometheus-redis-exporter
+```
+
+## Introduction
+
+This chart bootstraps a [redis_exporter](https://github.com/oliver006/redis_exporter) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.10+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `my-release`:
+
+```bash
+$ helm install --name my-release stable/prometheus-redis-exporter
+```
+
+The command deploys prometheus-redis-exporter on the Kubernetes cluster in the default configuration.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```bash
+$ helm delete my-release
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters and their default values.
+
+| Parameter              | Description                                         | Default                   |
+| ---------------------- | --------------------------------------------------- | ------------------------- |
+| `replicaCount`         | desired number of prometheus-redis-exporter pods    | `1`                       |
+| `image.repository`     | prometheus-redis-exporter image repository          | `oliver006/redis_exporter`|
+| `image.tag`            | prometheus-redis-exporter image tag                 | `v1.3.4`                 |
+| `image.pullPolicy`     | image pull policy                                   | `IfNotPresent`            |
+| `image.pullSecrets`    | image pull secrets                                  | {}                        |
+| `extraArgs`            | extra arguments for the binary; possible values [here](https://github.com/oliver006/redis_exporter#flags)| {}
+| `env`                  | additional environment variables in YAML format. Can be used to pass credentials as env variables (via secret) as per the image readme [here](https://github.com/oliver006/redis_exporter#environment-variables) | {} |
+| `resources`            | cpu/memory resource requests/limits                 | {}                        |
+| `tolerations`          | toleration labels for pod assignment                | {}                        |
+| `affinity`             | affinity settings for pod assignment                | {}                        |
+| `service.type`         | desired service type                                | `ClusterIP`               |
+| `service.port`         | service external port                               | `9121`                    |
+| `service.annotations`  | Custom annotations for service                      | `{}`                      |
+| `service.labels`       | Additional custom labels for the service            | `{}`                      |
+| `redisAddress`         | Address of the Redis instance to scrape. Use `rediss://` for SSL.      | `redis://myredis:6379`    |
+| `annotations`          | pod annotations for easier discovery                | {}                        |
+| `rbac.create`           | Specifies whether RBAC resources should be created.| `true` |
+| `rbac.pspEnabled`       | Specifies whether a PodSecurityPolicy should be created.| `true` |
+| `serviceAccount.create` | Specifies whether a service account should be created.| `true` |
+| `serviceAccount.name`   | Name of the service account.|        |
+| `serviceMonitor.enabled`       | Use servicemonitor from prometheus operator            | `false`                    |
+| `serviceMonitor.namespace`     | Namespace this servicemonitor is installed in          |                            |
+| `serviceMonitor.interval`      | How frequently Prometheus should scrape                |                            |
+| `serviceMonitor.telemetryPath` | Path to redis-exporter telemtery-path                  |                            |
+| `serviceMonitor.labels`        | Labels for the servicemonitor passed to Prometheus Operator      |  `{}`            |
+| `serviceMonitor.timeout`       | Timeout after which the scrape is ended                |                            |
+| `serviceMonitor.targetLabels`  | Set of labels to transfer on the Kubernetes Service onto the target.  |             |
+| `prometheusRule.enabled`           | Set this to true to create prometheusRules for Prometheus operator | `false`     |
+| `prometheusRule.additionalLabels`  | Additional labels that can be used so prometheusRules will be discovered by Prometheus  | `{}`  |
+| `prometheusRule.namespace`         | namespace where prometheusRules resource should be created |      |
+| `prometheusRule.rules`             | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created, check values for an example.                      | `[]`                                                    |
+| `script.configmap`     | Let you run a custom lua script from a configmap. The corresponding environment variable `REDIS_EXPORTER_SCRIPT` will be set automatically ||
+| `script.keyname`       | Name of the key inside configmap which contains your script ||
+| `auth.enabled`       | Specifies whether redis uses authentication | `false` |
+| `auth.secret.name`       | Name of existing redis secret (ignores redisPassword) ||
+| `auth.secret.key`       | Name of key containing password to be retrieved from the existing secret ||
+| `auth.redisPassword`       | Redis password (when not stored in a secret) ||
+
+For more information please refer to the [redis_exporter](https://github.com/oliver006/redis_exporter) documentation.
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install --name my-release \
+  --set "redisAddress=redis://myredis:6379" \
+    stable/prometheus-redis-exporter
+```
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install --name my-release -f values.yaml stable/prometheus-redis-exporter
+```
+### Using a custom LUA-Script
+First, you need to deploy the script with a configmap. This is an example script from mentioned in the [redis_exporter-image repository](https://github.com/oliver006/redis_exporter/blob/master/contrib/sample_collect_script.lua)
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-redis-exporter-script
+data:
+  script: |-
+    -- Example collect script for -script option
+    -- This returns a Lua table with alternating keys and values.
+    -- Both keys and values must be strings, similar to a HGETALL result.
+    -- More info about Redis Lua scripting: https://redis.io/commands/eval
+
+    local result = {}
+
+    -- Add all keys and values from some hash in db 5
+    redis.call("SELECT", 5)
+    local r = redis.call("HGETALL", "some-hash-with-stats")
+    if r ~= nil then
+        for _,v in ipairs(r) do
+            table.insert(result, v) -- alternating keys and values
+        end
+    end
+
+    -- Set foo to 42
+    table.insert(result, "foo")
+    table.insert(result, "42") -- note the string, use tostring() if needed
+
+    return result
+```
+If you want to use this script for collecting metrics, you could do this by just set `script.configmap` to the name of the configmap (e.g. `prometheus-redis-exporter-script`) and `script.keyname` to the configmap-key holding the script (eg. `script`). The required variables inside the container will be set automatically.
+
+## Upgrading
+
+### To 3.0.1
+
+ The default tag for the exporter image is now `v1.x.x`. This major release includes changes to the names of various metrics and no longer directly supports the configuration (and scraping) of multiple redis instances; that is now the Prometheus server's responsibility. You'll want to use [this dashboard](https://github.com/oliver006/redis_exporter/blob/master/contrib/grafana_prometheus_redis_dashboard.json) now. Please see the [redis_exporter github page](https://github.com/oliver006/redis_exporter#upgrading-from-0x-to-1x) for more details.

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/NOTES.txt
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/NOTES.txt
@@ -1,0 +1,15 @@
+1. Get the Redis Exporter URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "prometheus-redis-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "prometheus-redis-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "prometheus-redis-exporter.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.externalPort }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "prometheus-redis-exporter.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.internalPort }}
+{{- end }}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/_helpers.tpl
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "prometheus-redis-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "prometheus-redis-exporter.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "prometheus-redis-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "prometheus-redis-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "prometheus-redis-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/deployment.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/deployment.yaml
@@ -1,0 +1,98 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-redis-exporter.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      annotations:
+{{ toYaml .Values.annotations | indent 8 }}
+      labels:
+        app: {{ template "prometheus-redis-exporter.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
+      {{- if .Values.image.pullSecrets }}
+      imagePullSecrets:
+      {{- range .Values.image.pullSecrets }}
+        - name: {{ . }}
+      {{- end}}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          {{- range $key, $value := .Values.extraArgs }}
+            - --{{ $key }}={{ $value }}
+          {{- end }}
+          ports:
+            - name: exporter-port
+              containerPort: 9121
+          env:
+            - name: REDIS_ADDR
+              value: {{ .Values.redisAddress }}
+          {{- if .Values.auth.enabled }}
+            - name: REDIS_PASSWORD
+            {{- if .Values.auth.secret.name }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.auth.secret.name }}
+                  key: {{ .Values.auth.secret.key }}
+            {{- else }}
+              value: {{ .Values.auth.redisPassword }}
+            {{- end }}
+          {{- end }}
+{{- if .Values.script }}
+            - name: REDIS_EXPORTER_SCRIPT
+              value: /script/script.lua
+{{- end }}
+{{- if .Values.env }}
+{{ toYaml .Values.env | indent 12 }}
+{{- end }}
+{{- if .Values.script }}
+          volumeMounts:
+              - mountPath: /script
+                name: script-mount
+{{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: exporter-port
+          readinessProbe:
+            httpGet:
+              path: /
+              port: exporter-port
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- if .Values.script }}
+      volumes:
+        - name: script-mount
+          configMap:
+             name: {{ .Values.script.configmap }}
+             items:
+              - key: {{ .Values.script.keyname }}
+                path: script.lua
+    {{- end }}
+    {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/podsecuritypolicy.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.rbac.pspEnabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/prometheusrule.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+{{- with .Values.prometheusRule.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ template "prometheus-redis-exporter.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.prometheusRule.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.prometheusRule.rules }}
+  groups:
+    - name: {{ template "prometheus-redis-exporter.name" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/role.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/role.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.rbac.pspEnabled }}
+rules:
+- apiGroups:      ['extensions']
+  resources:      ['podsecuritypolicies']
+  verbs:          ['use']
+  resourceNames:  [{{ template "prometheus-redis-exporter.fullname" . }}]
+{{- end }}
+{{- end }}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/rolebinding.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
+{{- end -}}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/service.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: redis-exporter
+      port: {{ .Values.service.port }}
+      targetPort: exporter-port
+      protocol: TCP
+  selector:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    release: {{ .Release.Name }}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/serviceaccount.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "prometheus-redis-exporter.serviceAccountName" . }}
+  labels:
+    app: {{ template "prometheus-redis-exporter.name" . }}
+    chart: {{ template "prometheus-redis-exporter.chart" . }}
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end -}}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/servicemonitor.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/templates/servicemonitor.yaml
@@ -1,0 +1,41 @@
+{{- if $.Values.serviceMonitor }}
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.serviceMonitor.labels | indent 4}}
+{{- end }}
+  name: {{ template "prometheus-redis-exporter.fullname" . }}
+{{- if .Values.serviceMonitor.namespace }}
+  namespace: {{ .Values.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.service.port }}
+{{- if .Values.serviceMonitor.interval }}
+    interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.serviceMonitor.telemetryPath }}
+    path: {{ .Values.serviceMonitor.telemetryPath }}
+{{- end }}
+{{- if .Values.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.serviceMonitor.timeout }}
+{{- end }}
+  jobLabel: {{ template "prometheus-redis-exporter.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "prometheus-redis-exporter.name" . }}
+      release: {{ .Release.Name }}
+{{- if .Values.serviceMonitor.targetLabels }}
+{{- range .Values.serviceMonitor.targetLabels }}
+  targetLabels: 
+    - {{ . }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/values.yaml
+++ b/kubernetes/helm_charts/monitoring/prometheus-redis-exporter/values.yaml
@@ -1,0 +1,119 @@
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+  # Specifies whether a PodSecurityPolicy should be created
+  pspEnabled: true
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+replicaCount: 1
+image:
+  repository: oliver006/redis_exporter
+  tag: v1.3.4
+  pullPolicy: IfNotPresent
+extraArgs: {}
+# Additional Environment variables
+env: {}
+# - name: REDIS_PASSWORD
+#   valueFrom:
+#     secretKeyRef:
+#       key: redis-password
+#       name: redis-config-0.0.2
+service:
+  type: ClusterIP
+  port: 9121
+  annotations: {}
+  labels: {}
+    # prometheus.io/path: /metrics
+    # prometheus.io/port: "9121"
+    # prometheus.io/scrape: "true"
+resources: {}
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+redisAddress: redis://myredis:6379
+annotations: {}
+#  prometheus.io/path: /metrics
+#  prometheus.io/port: "9121"
+#  prometheus.io/scrape: "true"
+
+serviceMonitor:
+  # When set true then use a ServiceMonitor to configure scraping
+  enabled: false
+  # Set the namespace the ServiceMonitor should be deployed
+  # namespace: monitoring
+  # Set how frequently Prometheus should scrape
+  # interval: 30s
+  # Set path to redis-exporter telemtery-path
+  # telemetryPath: /metrics
+  # Set labels for the ServiceMonitor, use this to define your scrape label for Prometheus Operator
+  # labels:
+  # Set timeout for scrape
+  # timeout: 10s
+  # Set of labels to transfer on the Kubernetes Service onto the target.
+  # targetLabels: []
+
+## Custom PrometheusRules to be defined
+## The value is evaluated as a template, so, for example, the value can depend on .Release or .Chart
+## ref: https://github.com/coreos/prometheus-operator#customresourcedefinitions
+prometheusRule:
+  enabled: false
+  additionalLabels: {}
+  namespace: ""
+  rules: []
+    ## These are just examples rules, please adapt them to your needs.
+    ## Make sure to constraint the rules to the current service.
+    #  - alert: RedisDown
+    #    expr: redis_up{service="{{ template "prometheus-redis-exporter.fullname" . }}"} == 0
+    #    for: 2m
+    #    labels:
+    #      severity: error
+    #    annotations:
+    #      summary: Redis instance {{ "{{ $labels.instance }}" }} down
+    #      description: Redis instance {{ "{{ $labels.instance }}" }} is down.
+    #  - alert: RedisMemoryHigh
+    #    expr: >
+    #       redis_memory_used_bytes{service="{{ template "prometheus-redis-exporter.fullname" . }}"} * 100
+    #       /
+    #       redis_memory_max_bytes{service="{{ template "prometheus-redis-exporter.fullname" . }}"}
+    #       > 90 <= 100
+    #    for: 2m
+    #    labels:
+    #      severity: error
+    #    annotations:
+    #      summary: Redis instance {{ "{{ $labels.instance }}" }} is using too much memory
+    #      description: |
+    #         Redis instance {{ "{{ $labels.instance }}" }} is using {{ "{{ $value }}" }}% of its available memory.
+    #  - alert: RedisKeyEviction
+    #    expr: |
+    #      increase(redis_evicted_keys_total{service="{{ template "prometheus-redis-exporter.fullname" . }}"}[5m]) > 0
+    #    for: 1s
+    #    labels:
+    #      severity: error
+    #    annotations:
+    #      summary: Redis instance {{ "{{ $labels.instance }}" }} has evicted keys
+    #      description: |
+    #        Redis instance {{ "{{ $labels.instance }}" }} has evicted {{ "{{ $value }}" }} keys in the last 5 minutes.
+
+# Used to mount a LUA-Script via config map and use it for metrics-collection
+# script:
+#   configmap: prometheus-redis-exporter-script
+#   keyname: script
+
+auth:
+  # Use password authentication
+  enabled: false
+  # Use existing secret (ignores redisPassword)
+  secret:
+    name: ""
+    key: ""
+  # Redis password (when not stored in a secret)
+  redisPassword: ""

--- a/private_repo/ansible/inventory/dev/Core/hosts
+++ b/private_repo/ansible/inventory/dev/Core/hosts
@@ -121,6 +121,9 @@ lp-redis
 [redis-ps:children]
 lp-redis-ps           
 
+[redis-exporter-targets:children]
+lp-redis
+
 [learning-neo4j-node1]
 15.0.2.9             # Neo4j ip of Knowledge platform
 


### PR DESCRIPTION
This implementation will allow to scrape multiple redis
instances with one exporter

### Will have to add these to inventory
```
[redis-1]
10.0.1.1
[redis-2]
10.0.1.2
[redis-exporter-targets:children]
redis-1
redis-2
```
in prometheus these two machines will be monitored and grafana will 
auto populate these instances