### PR TITLE
Removing force installation of helm charts for monitoring

### DIFF
--- a/kubernetes/ansible/roles/sunbird-monitoring/tasks/main.yml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/tasks/main.yml
@@ -7,7 +7,7 @@
   with_items: "{{ monitoring_stack }}"
 
 - name: Creating sunbird monitoring stack
-  shell: "helm upgrade --install --force --cleanup-on-fail {{ item }} {{chart_path}}/{{ item }} --namespace monitoring -f /tmp/{{ item }}.yaml"
+  shell: "helm upgrade --install --cleanup-on-fail {{ item }} {{chart_path}}/{{ item }} --namespace monitoring -f /tmp/{{ item }}.yaml"
   with_items: "{{ monitoring_stack }}"
 
 - name: Creating sunbird monitoring grafana dashboards
@@ -16,6 +16,6 @@
     - dashboards
 
 - name: Install statsd-exporter
-  shell: "helm upgrade --install --force --cleanup-on-fail statsd-exporter {{chart_path}}/statsd-exporter --namespace {{ namespace }}"
+  shell: "helm upgrade --install --cleanup-on-fail statsd-exporter {{chart_path}}/statsd-exporter --namespace {{ namespace }}"
   tags:
     - statsd-exporter


### PR DESCRIPTION
This was the reason for redis-exporter was complaining clusterIP is
immutable