### PR TITLE
Cassandra backup seriallization

### DIFF
--- a/ansible/cassandra-backup.yml
+++ b/ansible/cassandra-backup.yml
@@ -1,7 +1,23 @@
+#  This task will take snapshot serially for all cassandra nodes
+#  If we club both taking snapshot and upload the data, then the
+#  interval of snapshots b/w nodes will be very high; Which might lead
+#  to data discrepancies
 - hosts: cassandra
   become: yes
-  serial: 1
+  serial: true
+  tasks:
+  - name: taking cassandra snapshots
+    shell: |
+      nodetool clearsnapshot
+      nodetool snapshot -t "cassandra-backup-{{ lookup('pipe', 'date +%Y%m%d') }}-{{ ansible_hostname }}"
+
+# Once snaphot is done, 
+# We can take the snapshot and compress it and upload it
+# This will take some cpu and memory in the nodes
+# Because of that we're running it serially, so that it won't affect the perfomance
+- hosts: cassandra
+  serial: true
   vars_files:
     - ['{{ inventory_dir }}/secrets.yml']
   roles:
-    - cassandra-backup
+    - {name: cassandra-backup, vars: [ additional_arguments: "--disablesnapshot"]}

--- a/ansible/cassandra-backup.yml
+++ b/ansible/cassandra-backup.yml
@@ -17,6 +17,7 @@
 # Because of that we're running it serially, so that it won't affect the perfomance
 - hosts: cassandra
   serial: true
+  become: yes
   vars_files:
     - ['{{ inventory_dir }}/secrets.yml']
   roles:

--- a/ansible/cassandra-backup.yml
+++ b/ansible/cassandra-backup.yml
@@ -21,7 +21,6 @@
 # This will take some cpu and memory in the nodes
 # Because of that we're running it serially, so that it won't affect the perfomance
 - hosts: cassandra
-  serial: true
   become: yes
   vars_files:
     - ['{{ inventory_dir }}/secrets.yml']

--- a/ansible/cassandra-backup.yml
+++ b/ansible/cassandra-backup.yml
@@ -10,6 +10,11 @@
     shell: |
       nodetool clearsnapshot
       nodetool snapshot -t "cassandra-backup-{{ lookup('pipe', 'date +%Y%m%d') }}-{{ ansible_hostname }}"
+  - name: sleeping 1 min b/w snapshots
+    pause:
+      echo: true
+      minutes: 1 # A positive number of minutes to pause for.
+      prompt: "Pausing after snapshot" # Optional text to use for the prompt message.
 
 # Once snaphot is done, 
 # We can take the snapshot and compress it and upload it

--- a/ansible/roles/azure-cli/tasks/main.yml
+++ b/ansible/roles/azure-cli/tasks/main.yml
@@ -1,2 +1,3 @@
 - name: install azure cli
-  shell: curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  shell: 
+    which az || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash

--- a/ansible/roles/cassandra-backup/tasks/main.yml
+++ b/ansible/roles/cassandra-backup/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: run the backup script
   become: yes
-  shell: python cassandra_backup.py --snapshotname "{{ cassandra_backup_gzip_file_name }}"
+  shell: python3 cassandra_backup.py --snapshotname "{{ cassandra_backup_gzip_file_name }}"
   args:
     chdir: /data/cassandra/backup
   async: 7200

--- a/ansible/roles/cassandra-backup/tasks/main.yml
+++ b/ansible/roles/cassandra-backup/tasks/main.yml
@@ -4,7 +4,10 @@
 
 - name: copy the backup script
   become: yes
-  template: src=cassandra_backup.j2  dest=/data/cassandra/backup/cassandra_backup.py mode=0755
+  template:
+    src: ../../../../deploy/cassandra_backup.py 
+    dest: /data/cassandra/backup/cassandra_backup.py
+    mode: 0755
 
 - set_fact:
     cassandra_backup_gzip_file_name: "cassandra-backup-{{ lookup('pipe', 'date +%Y%m%d') }}-{{ ansible_hostname }}"
@@ -14,7 +17,7 @@
 
 - name: run the backup script
   become: yes
-  shell: python3 cassandra_backup.py --snapshotname "{{ cassandra_backup_gzip_file_name }}"
+  shell: python3 cassandra_backup.py --snapshotname "{{ cassandra_backup_gzip_file_name }}" "{{additional_arguments|d('')}}"
   args:
     chdir: /data/cassandra/backup
   async: 7200

--- a/deploy/cassandra_backup.py
+++ b/deploy/cassandra_backup.py
@@ -84,8 +84,6 @@ if rc != 0:
     print("Couldn't backup schema, exiting...")
     exit(1)
 print("Schema backup completed. saved in {}/cassandra_backup/db_schema.sql".format(tmpdir))
-# Default value for snapshot
-rc = 0
 
 # Creating snapshots
 if not args.disablesnapshot:
@@ -95,17 +93,21 @@ if not args.disablesnapshot:
     # Taking new snapshot
     command = "nodetool snapshot -t {}".format(args.snapshotname)
     rc = system(command)
-if rc == 0:
-    if not args.disablesnapshot:
-        print("Snapshot taken.")
-    copy()
-    print("Making a tarball: {}.tar.gz".format(args.snapshotname))
-    command = "cd {} && tar --remove-files -czvf {}/{}.tar.gz *".format(tmpdir, args.tardirectory, args.snapshotname)
-    rc = system(command)
     if rc != 0:
-        print("Creation of tar failed")
+        print("Backup failed")
         exit(1)
-    # Cleaning up backup directory
-    rmtree(tmpdir)
-    print("Cassandra backup completed and stored in {}/{}.tar.gz".format(args.tardirectory, args.snapshotname))
+    print("Snapshot taken.")
+
+# Copying the snapshot to proper folder structure
+copy()
+# Creating tarball
+print("Making a tarball: {}.tar.gz".format(args.snapshotname))
+command = "cd {} && tar --remove-files -czvf {}/{}.tar.gz *".format(tmpdir, args.tardirectory, args.snapshotname)
+rc = system(command)
+if rc != 0:
+    print("Creation of tar failed")
+    exit(1)
+# Cleaning up backup directory
+rmtree(tmpdir)
+print("Cassandra backup completed and stored in {}/{}.tar.gz".format(args.tardirectory, args.snapshotname))
 

--- a/deploy/cassandra_backup.py
+++ b/deploy/cassandra_backup.py
@@ -19,7 +19,7 @@ eg: ./cassandra_backup.py
 for help ./cassandra_backup.py -h
 '''
 
-from os import walk, sep, system, getcwd, makedirs
+from os import walk, sep, system, getcwd, makedirs, cpu_count
 from argparse import ArgumentParser
 from shutil import rmtree, ignore_patterns, copytree
 from re import match, compile
@@ -36,6 +36,8 @@ parser.add_argument("-s", "--snapshotname", metavar="snapshotname",
                     help="Name with which snapshot to be taken. Default {}".format("cassandra_backup-"+strftime("%Y-%m-%d")))
 parser.add_argument("-t", "--tardirectory", metavar="tardir",
                     default=getcwd(), help="Path to create the tarball. Default {}".format(getcwd()))
+parser.add_argument("-w", "--workers", metavar="workers",
+                    default=cpu_count(), help="Number of workers to use. Default same as cpu cores {}".format(cpu_count()))
 parser.add_argument("--disablesnapshot", action="store_true",
                     help="disable taking snapshot, snapshot name can be given via -s flag")
 args = parser.parse_args()
@@ -57,7 +59,7 @@ def copy():
     # List of the threds running in background
     futures = []
     try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=args.workers) as executor:
             for root, dirs, files in walk(args.datadirectory):
                 root_target_dir = tmpdir+sep+"cassandra_backup"+sep+sep.join(root.split(sep)[root_levels+1:-2])
                 if match(ignore_list, root_target_dir):

--- a/deploy/cassandra_backup.py
+++ b/deploy/cassandra_backup.py
@@ -57,7 +57,7 @@ def copy():
     # List of the threds running in background
     futures = []
     try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
             for root, dirs, files in walk(args.datadirectory):
                 root_target_dir = tmpdir+sep+"cassandra_backup"+sep+sep.join(root.split(sep)[root_levels+1:-2])
                 if match(ignore_list, root_target_dir):

--- a/deploy/cassandra_backup.py
+++ b/deploy/cassandra_backup.py
@@ -101,7 +101,10 @@ if rc == 0:
     copy()
     print("Making a tarball: {}.tar.gz".format(args.snapshotname))
     command = "cd {} && tar -czvf {}/{}.tar.gz *".format(tmpdir, args.tardirectory, args.snapshotname)
-    system(command)
+    rc = system(command)
+    if rc != 0:
+        print("Creation of tar failed")
+        exit(1)
     # Cleaning up backup directory
     rmtree(tmpdir)
     print("Cassandra backup completed and stored in {}/{}.tar.gz".format(args.tardirectory, args.snapshotname))

--- a/deploy/cassandra_backup.py
+++ b/deploy/cassandra_backup.py
@@ -100,7 +100,7 @@ if rc == 0:
         print("Snapshot taken.")
     copy()
     print("Making a tarball: {}.tar.gz".format(args.snapshotname))
-    command = "cd {} && tar -czvf {}/{}.tar.gz *".format(tmpdir, args.tardirectory, args.snapshotname)
+    command = "cd {} && tar --remove-files -czvf {}/{}.tar.gz *".format(tmpdir, args.tardirectory, args.snapshotname)
     rc = system(command)
     if rc != 0:
         print("Creation of tar failed")

--- a/deploy/cassandra_backup.py
+++ b/deploy/cassandra_backup.py
@@ -71,8 +71,7 @@ def copy():
     # Checking status of the copy operation
     for future in concurrent.futures.as_completed(futures):
         try:
-            print("Task completed for ...")
-            print(future.result())
+            print("Task completed. Result: {}".format(future.result()))
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
1. Take snapshot serially as this is a blocking operation, if done
   simultaneously, write requests to cassandra will fail.
2. copy the data and upload to azure blob serially
   because this operation will take time and resources,
   so better do one at a time, so that other instances will be
   free for core operations