### PR TITLE
SB-19349: point downloadCertificate api to cert-registry

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -1161,7 +1161,7 @@ kong_apis:
 
   - name: downloadCertificate
     uris: "{{ user_service_prefix }}/v1/certs/download"
-    upstream_url: "{{ learning_service_url }}/v1/user/certs/download"
+    upstream_url: "{{ cert_registry_service_url }}/certs/v1/registry/download"
     strip_uri: true
     plugins:
     - name: jwt


### PR DESCRIPTION
For download cert, the learner-service holds the endpoint for older mobile clients.
so changing the kong configuration to point to cert-registry rather than learner-service