### PR TITLE
Issue #1664: Adding Alert deduplication

### DIFF
--- a/kubernetes/ansible/roles/sunbird-monitoring/defaults/main.yml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/defaults/main.yml
@@ -174,3 +174,9 @@ processing_cluster_kafka: "{{ groups['processing-cluster-kafka'] | difference(['
 
 ingestion_cluster_zookeeper: "{{ groups['ingestion-cluster-zookeeper'] | difference(['localhost']) | map('regex_replace', '^(.*)$', '\\1:2181') | list}}"
 ingestion_cluster_kafka: "{{ groups['ingestion-cluster-kafka'] | difference(['localhost']) | map('regex_replace', '^(.*)$', '\\1:9092') | list}}"
+
+# These varaibles can be overridden in common.yaml
+prometheus_spec_overrides:
+  sb_test_var: dummy_var_not_to_throw_error
+alertmanager_spec_overrides:
+  sb_test_var: dummy_var_not_to_throw_error

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-operator.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-operator.yaml
@@ -8,6 +8,44 @@
 #}
 fullnameOverride: sunbird-monitoring
 
+# This is to override/add configurations of prometheusSpec by user
+# you can add this variable in common.yaml and that will get merged / preferred
+# over the below variables.
+ 
+# for example:
+#
+# prometheus_spec_overrides:
+#   additionalAlertManagerConfigs:
+#     - static_configs:
+#       - targets:
+#         - sunbird-monitoring-alertmanager.monitoring.svc.cluster.local:9093
+#         - 28.0.33.125:9093
+#   additionalAlertRelabelConfigs:
+#   - source_labels: [sb_cluster]
+#     regex: (.+)\d+
+#     target_label: sb_cluster
+
+
+# yaml anchor for prometheusspec over ride
+prometheus_spec_overrides: &prometheus_spec_overrides
+  {{ prometheus_spec_overrides | to_yaml | indent( width=2) }}
+
+# For Example:
+#
+# alertmanager_spec_overrides:
+#   service:
+#     annotations:
+#       service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+#     type: LoadBalancer
+#     # make sure this ip is in valid ip range
+#     # For aws this won't work, as aws will only give domain_name
+#     loadBalancerIP: "10.0.0.10" 
+
+# Yaml anchor for alertmanager
+alertmanager_spec_overrides: &alertmanager_spec_overrides
+  {{ alertmanager_spec_overrides | to_yaml | indent( width=2) }}
+
+
 # Enabling external prometheus scrape config 
 prometheus:
   prometheusSpec:
@@ -23,6 +61,9 @@ prometheus:
 {% if prometheus_storage_spec is defined and prometheus_storage_spec %}
     storageSpec: {{ prometheus_storage_spec|to_json }}
 {% endif %}
+    # Adding prometeus custom spec overrides 
+    # Refering promtheus sepc override yaml anchor
+    <<: *prometheus_spec_overrides
 {% if prometheus_service is defined and prometheus_service %}
   service: {{ (prometheus_service | to_json) }}
 {% endif %}
@@ -132,6 +173,10 @@ alertmanager:
             html: '{% raw %}{{ template "email.default.html" . }}{% endraw %}'
             headers:
               subject: '[{{ kubernetes_cluster_name }}] {% raw %}{{ .GroupLabels.alertname }}{% endraw %}'
+
+  # Adding alertmanager custom spec overrides 
+  # Refrencing alert manager yaml anchor
+  <<: *alertmanager_spec_overrides
 
 
 grafana:


### PR DESCRIPTION
Users can override the default Prometheus/Alertmanager specs
in common.yaml
By default Ansible won't do dictionary merge and moving the complete
file to default/main.yaml doesn't' looks like a good solution as this is
a template. So using yaml anchors.
At run time helm will populate the anchor with referred dictionary.
But for yaml anchoring, dictionary can't be empty. So adding dummy
values in default/main.yaml. That value won't come in final ansible
template.