### PR TITLE
SB-20285 PU - Adding env variables for maximum limit on groups, members, activities

### DIFF
--- a/ansible/roles/stack-sunbird/templates/sunbird_groups-service.env
+++ b/ansible/roles/stack-sunbird/templates/sunbird_groups-service.env
@@ -29,4 +29,10 @@ sunbird_user_service_search_url=/private/user/v1/search
 sunbird_cs_search_url=/v3/search
 ENV_NAME={{env_name}}
 SUNBIRD_KAFKA_URL={{kafka_urls}}
+max_group_members_limit={{max_group_members_limit | default(150)}}
+max_activity_limit={{max_activity_limit | default(100)}}
+max_group_limit={{max_group_limit | default(50)}}
+enable_userid_redis_cache={{enable_userid_redis_cache | default(true)}}
+groups_redis_ttl={{groups_redis_ttl | default(86400)}}
+user_redis_ttl={{user_redis_ttl | default(3600)}}
 


### PR DESCRIPTION
Adding env variables for
Maximum number of groups that can be created - 50
Maximum number of members that can be added in a group - 150 
Maximum number of activities that can be added for a group - 100