### PR TITLE
Added the secor process alert rules.

### DIFF
--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/alertrules.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/alertrules.yaml
@@ -59,3 +59,6 @@ raw_druid_datasource:
 druid_raw_ingestion_threshold: 200000
 druid_rollup_ingestion_threshold: 200000
 
+secor_process_names:
+  - raw-telemetry-backup
+  - telemetry-duplicate-backup

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/alertrules.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/alertrules.yaml
@@ -43,3 +43,19 @@ kafka_telemetry_ingestion_backup_threshold_critical: "{{ kafka_telemetry_ingesti
 kafka_telemetry_unique_backup_threshold_critical: "{{ kafka_telemetry_unique_backup_threshold_critical }}"
 summary_backup_threshold_critical: "{{ summary_backup_threshold_critical }}"
 summary_channel_backup_threshold_critical: "{{ summary_channel_backup_threshold_critical }}"
+
+
+raw_druid_datasource:
+  - content-model-snapshot
+  - offline-desktop-events
+  - summary-events
+  - telemetry-events-syncts
+  - telemetry-feedback-events
+  - audit-rollup-syncts
+  - sl_observation_status
+  - sl_observations_production
+  - telemetry-feedback-events
+
+druid_raw_ingestion_threshold: 200000
+druid_rollup_ingestion_threshold: 200000
+

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/alertrules.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/alertrules.yaml
@@ -60,5 +60,22 @@ druid_raw_ingestion_threshold: 200000
 druid_rollup_ingestion_threshold: 200000
 
 secor_process_names:
+  - channel-telemetry-backup
+  - derived-telemetry-backup
+  - derived-denorm-events-backup
+  - channel-summary-backup
+  - assess-events-backup
+  - assess-raw-events-backup
+  - device-profile-backup
+  - learning-events-backup
+  - learning-failed-backup
+  - content-consumption-events-backup
+  - failed-telemetry-backup
+  - extractor-duplicate-backup
+  - extractor-failed-backup
+  - unique-telemetry-backup
+  - denorm-events-backup
   - raw-telemetry-backup
-  - telemetry-duplicate-backup
+  - ingestion-telemetry-backup
+  - ingestion-cluster-telemetry-backup
+  - telemetry-ingest-backup

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-operator.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-operator.yaml
@@ -150,6 +150,13 @@ alertmanager:
                     *Details:* {{ "{{" }} .Annotations.message {{ "}}" }}
                   {{ "{{" }} end {{ "}}" }}
             icon_emoji: ':dart:'
+    
+        email_configs:
+          - send_resolved: true
+            to: '{{ default_mailing_list }}'
+            html: '{% raw %}{{ template "email.default.html" . }}{% endraw %}'
+            headers:
+              subject: '[{{ kubernetes_cluster_name }}] {% raw %}{{ .GroupLabels.alertname }}{% endraw %}'
 
       - name: 'dp-lag_slack_warning'
         slack_configs:
@@ -168,6 +175,13 @@ alertmanager:
                     *Details:* {{ "{{" }} .Annotations.message {{ "}}" }}
                     {{ "{{" }} end {{ "}}" }}
             icon_emoji: ':dart:'
+            
+        email_configs:
+          - send_resolved: true
+            to: '{{ default_mailing_list }}'
+            html: '{% raw %}{{ template "email.default.html" . }}{% endraw %}'
+            headers:
+              subject: '[{{ kubernetes_cluster_name }}] {% raw %}{{ .GroupLabels.alertname }}{% endraw %}'
 
       - name: 'dp-lag_slack_critical'
         slack_configs:
@@ -186,6 +200,13 @@ alertmanager:
                     *Details:* {{ "{{" }} .Annotations.message {{ "}}" }}
                     {{ "{{" }} end {{ "}}" }}
             icon_emoji: ':dart:'
+            
+        email_configs:
+          - send_resolved: true
+            to: '{{ default_mailing_list }}'
+            html: '{% raw %}{{ template "email.default.html" . }}{% endraw %}'
+            headers:
+              subject: '[{{ kubernetes_cluster_name }}] {% raw %}{{ .GroupLabels.alertname }}{% endraw %}'
 
       {% for item in alert_teams %}
       # Comment to ensure proper indentation while templating

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-operator.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/prometheus-operator.yaml
@@ -145,7 +145,7 @@ alertmanager:
             text: |-
                   {{ "{{" }} range .Alerts {{ "}}" }}
                      *Alert:* {{ "{{" }} .Annotations.alertname {{ "}}" }}
-                    *processName:* {{ "{{" }} .Annotations.job_id {{ "}}" }}
+                    *ProcessName:* {{ "{{" }} .Annotations.job_id {{ "}}" }}
                     *AlertType:* {{ "{{" }} .Labels.severity {{ "}}" }}
                     *Details:* {{ "{{" }} .Annotations.message {{ "}}" }}
                   {{ "{{" }} end {{ "}}" }}

--- a/kubernetes/helm_charts/monitoring/alertrules/templates/promrulesDruid.yml
+++ b/kubernetes/helm_charts/monitoring/alertrules/templates/promrulesDruid.yml
@@ -1,0 +1,103 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    role: alert-rules
+    app: {{ .Values.prometheus_rule_selector_app }}
+    release: {{ .Values.prometheus_rule_selector_release }}
+  name: {{ .Values.fullnameOverride }}-druid-rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+  - name: alertrules.process
+    rules:
+    {{- if .Values.raw_druid_datasource }}
+    ## druid segment unavailable count alert
+    {{ range $key := .Values.raw_druid_datasource }}
+    - alert: druid_segment_unavailable_count
+      expr: druid_segment_unavailable_count{exported_job={{ . | quote }}} > 0
+      for: 5m
+      labels:
+        severity: critical
+        module: dp_lag
+      annotations:
+        message: The druid segment unavailable count for the datasource {{ . }} is greater than 0.
+        lag: {{`({{ humanize $value }})`}}
+        job_id: Druid
+        alertname: DruidSegmentUnavailable
+    {{- end }}
+     ### kafka druid ingest lag
+    {{ range $key := .Values.raw_druid_datasource }}
+    - alert: druid_ingest_kafka_lag
+      expr: druid_ingest_kafka_lag{exported_job={{ . | quote }}} > {{ $.Values.druid_raw_ingestion_threshold }}
+      for: 5m
+      labels:
+        severity: critical
+        module: dp_lag
+      annotations:
+        message: The druid ingestion lag for datasource {{ . }} is greater than threshold {{ $.Values.druid_raw_ingestion_threshold | int }}
+        lag: {{`({{ humanize $value }})`}}
+        job_id: Druid
+        alertname: DruidKafkaIngestionLag
+    {{- end }}
+     ### druid ingest handoff failed alert rules
+    {{ range $key := .Values.raw_druid_datasource }}
+    - alert: druid_ingest_handoff_failed
+      expr: druid_ingest_handoff_failed{exported_job={{ . | quote }}} > 0
+      for: 5m
+      labels:
+        severity: critical
+        module: dp_lag
+      annotations:
+        message: The druid ingest handoff failed count for datasource {{ . }} is greater than 0.
+        lag: {{`({{ humanize $value }})`}}
+        job_id: Druid
+        alertname: DruidIngestHandoffFailed
+    {{- end }}
+    {{- end }}
+
+    {{- if .Values.rollup_druid_cluster }}
+    ## druid segment unavailable count alert
+    {{ range $key := .Values.rollup_druid_datasource }}
+    - alert: druid_segment_unavailable_count
+      expr: druid_segment_unavailable_count{exported_job={{ . | quote }}} > 0
+      for: 5m
+      labels:
+        severity: critical
+        module: dp_lag
+      annotations:
+        message: The druid segment unavailable count for the datasource {{ . }} is greater than 0.
+        lag: {{`({{ humanize $value }})`}}
+        job_id: Druid
+        alertname: DruidSegmentUnavailable
+    {{- end }}
+     ### kafka druid ingest lag
+    {{ range $key := .Values.rollup_druid_datasource }}
+    - alert: druid_ingest_kafka_lag
+      expr: druid_ingest_kafka_lag{exported_job={{ . | quote }}} > {{ $.Values.druid_rollup_ingestion_threshold }}
+      for: 5m
+      labels:
+        severity: critical
+        module: dp_lag
+      annotations:
+        message: The druid ingestion lag for datasource {{ . }} is greater than {{ $.Values.druid_rollup_ingestion_threshold | int }}
+        lag: {{`({{ humanize $value }})`}}
+        job_id: Druid
+        alertname: DruidKafkaIngestionLag
+    {{- end }}
+     ### druid ingest handoff failed alert rules
+    {{ range $key := .Values.rollup_druid_datasource }}
+    - alert: druid_ingest_handoff_failed
+      expr: druid_ingest_handoff_failed{exported_job={{ . | quote }}} > 0
+      for: 5m
+      labels:
+        severity: critical
+        module: dp_lag
+      annotations:
+        message: The druid ingest handoff failed count for datasource {{ . }} is greater than 0.
+        lag: {{`({{ humanize $value }})`}}
+        job_id: Druid
+        alertname: DruidIngestHandoffFailed
+    {{- end }}
+    {{- end }} 

--- a/kubernetes/helm_charts/monitoring/alertrules/templates/promrulesProcess.yml
+++ b/kubernetes/helm_charts/monitoring/alertrules/templates/promrulesProcess.yml
@@ -60,30 +60,6 @@ spec:
         job_id: kafka
         alertname: TooManyKafkaProcessRunning
 
-    - alert: secor_process_not_running_critical
-      expr: namedprocess_namegroup_states{groupname="secor",state="Sleeping"} != {{ .Values.secor_job_count }}
-      for: 1m
-      labels:
-        severity: critical
-        module: dp_process
-      annotations:
-        message: Number of running processes should be {{ .Values.secor_job_count }} but currently {{`{{$value}}`}} processes are running.
-        summary: Secor process is not running
-        job_id: secor
-        alertname: SecorJobNotRunning
-
-    - alert: secor_process_not_running_critical
-      expr: namedprocess_namegroup_states{groupname="processingsecor",state="Sleeping"} != {{ .Values.processingsecor_job_count }}
-      for: 1m
-      labels:
-        severity: critical
-        module: dp_process
-      annotations:
-        message: Number of running processes should be {{ .Values.secor_job_count }} but currently {{`{{$value}}`}} processes are running.
-        summary: Secor process is not running
-        job_id: secor
-        alertname: SecorJobNotRunning
-
     - alert: zookeeper_process_not_running_fatal
       expr: namedprocess_namegroup_states{groupname="zookeeper",state="Sleeping"} < 1
       for: 1m

--- a/kubernetes/helm_charts/monitoring/alertrules/templates/promrulesSecorProcess.yml
+++ b/kubernetes/helm_charts/monitoring/alertrules/templates/promrulesSecorProcess.yml
@@ -15,14 +15,14 @@ spec:
     {{- if .Values.secor_process_names }}
     ## druid segment unavailable count alert
     {{ range $key := .Values.secor_process_names }}
-    - alert: secor_process_not_running_critical
+    - alert: secor_process_not_running_critical {{ . }}
       expr: sum without(state) (namedprocess_namegroup_states{groupname={{ . | quote }}}) == 0
       for: 5m
       labels:
         severity: critical
         module: dp_process
       annotations:
-        message: The secor jobs {{ . }} is not running
+        message: The secor job {{ . }} is not running.
         job_id: {{ . }}
         alertname: SecorJobNotRunning
     {{- end }}

--- a/kubernetes/helm_charts/monitoring/alertrules/templates/promrulesSecorProcess.yml
+++ b/kubernetes/helm_charts/monitoring/alertrules/templates/promrulesSecorProcess.yml
@@ -1,0 +1,29 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    role: alert-rules
+    app: {{ .Values.prometheus_rule_selector_app }}
+    release: {{ .Values.prometheus_rule_selector_release }}
+  name: {{ .Values.fullnameOverride }}-secor-process-rules
+  namespace: {{ .Values.namespace }}
+spec:
+  groups:
+  - name: alertrules.process
+    rules:
+    {{- if .Values.secor_process_names }}
+    ## druid segment unavailable count alert
+    {{ range $key := .Values.secor_process_names }}
+    - alert: secor_process_not_running_critical
+      expr: sum without(state) (namedprocess_namegroup_states{groupname={{ . | quote }}}) == 0
+      for: 5m
+      labels:
+        severity: critical
+        module: dp_process
+      annotations:
+        message: The secor jobs {{ . }} is not running
+        job_id: {{ . }}
+        alertname: SecorJobNotRunning
+    {{- end }}
+    {{- end }} 


### PR DESCRIPTION
This PR includes sending the alerts for individual secor process not running. Sample alert below. 

`[FIRING:1]
Alert: SecorJobNotRunning
 ProcessName: raw-telemetry-backup
 AlertType: critical
 Details: The secor jobs raw-telemetry-backup is not running`