### PR TITLE
fixes negative stride ansible error when keys are zero

### DIFF
--- a/kubernetes/ansible/roles/helm-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/helm-deploy/defaults/main.yml
@@ -98,7 +98,7 @@ adminutil_keys_values:
     basepath: "/keys/"
     keyprefix: "{{ adminutil__device_keyprefix }}"
     keystart: "{{ adminutil__device_keystart }}"
-    keycount: "{{ adminutil__device_keystart + adminutil__device_keycount - 1 }}"
+    keycount: "{{ adminutil__device_keycount|int }}"
   role_to_run:
     - decrypt.yml
     - copy-to-helm.yml
@@ -107,7 +107,7 @@ adminutil_keys_values:
     basepath: "/keys/"
     keyprefix: "{{ adminutil__access_keyprefix }}"
     keystart: "{{ adminutil__access_keystart }}"
-    keycount: "{{ adminutil__access_keystart + adminutil__access_keycount - 1 }}"
+    keycount: "{{ adminutil__access_keycount|int }}"
   role_to_run:
     - decrypt.yml
     - copy-to-helm.yml
@@ -116,7 +116,7 @@ adminutil_keys_values:
     basepath: "/keys/"
     keyprefix: "{{ adminutil__desktop_keyprefix }}"
     keystart: "{{ adminutil__desktop_keystart }}"
-    keycount: "{{ adminutil__desktop_keystart + adminutil__desktop_keycount - 1 }}"
+    keycount: "{{ adminutil__desktop_keycount|int }}"
   role_to_run:
     - decrypt.yml
     - copy-to-helm.yml

--- a/kubernetes/ansible/roles/helm-deploy/tasks/main.yml
+++ b/kubernetes/ansible/roles/helm-deploy/tasks/main.yml
@@ -22,7 +22,7 @@
     private_key_path: "{{ outer_item.0.values_to_pass.basepath }}"
     private_key_prefix: "{{ outer_item.0.values_to_pass.keyprefix }}"
     private_key_sign_start: "{{ outer_item.0.values_to_pass.keystart }}"
-    private_key_sign_end: "{{ outer_item.0.values_to_pass.keycount if outer_item.0.values_to_pass.keycount > '0' else '0'  }}"
+    private_key_sign_end: "{{ outer_item.0.values_to_pass.keycount if outer_item.0.values_to_pass.keycount > '0' else '1'  }}"
   when: release_name == "adminutils"
   with_subelements:
     - "{{adminutil_keys_values}}"

--- a/kubernetes/ansible/roles/sunbird-deploy/tasks/main.yml
+++ b/kubernetes/ansible/roles/sunbird-deploy/tasks/main.yml
@@ -26,7 +26,7 @@
     private_key_path: "{{ outer_item.0.values_to_pass.basepath }}"
     private_key_prefix: "{{ outer_item.0.values_to_pass.keyprefix }}"
     private_key_sign_start: "{{ outer_item.0.values_to_pass.keystart }}"
-    private_key_sign_end: "{{ outer_item.0.values_to_pass.keycount if outer_item.0.values_to_pass.keycount > '0' else '0'  }}"
+    private_key_sign_end: "{{ outer_item.0.values_to_pass.keycount if outer_item.0.values_to_pass.keycount > '0' else '1'  }}"
   when: release_name == "learner" or release_name == "lms" or release_name == "groups"
   with_subelements:
     - "{{adminutil_access_values}}"


### PR DESCRIPTION
- When keys are zero, due to n - 1 logic, we would end up as -1 for end and start as 0
- To count backwards stride should be specified as -1 which we will never use
- Fixes bug in total key count looping when keys start with a number greater than 1 as the start (example - 11 to 20)