### PR TITLE
feat: TG-532 Portal v2 api devops scripts

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -3188,6 +3188,24 @@ kong_apis:
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
 
+  - name: registerPortalv2
+    uris: "{{ api_manager_perfix }}/v2/consumer/portal/credential/register"
+    upstream_url: "{{ am_util_url }}/v2/consumer/portal/credential/register"
+    strip_uri: true
+    plugins:
+    - name: jwt
+    - name: cors
+    - "{{ statsd_pulgin }}"
+    - name: acl
+      config.whitelist:
+        - 'mobileAdmin'
+    - name: rate-limiting
+      config.policy: local
+      config.hour: "{{ medium_rate_limit_per_hour }}"
+      config.limit_by: credential
+    - name: request-size-limiting
+      config.allowed_payload_size: "{{ small_request_size_limit }}"
+
   - name: registerMobileDeviceOpenRAP
     uris: "{{ api_manager_perfix }}/v1/consumer/mobile_device_openrap/credential/register"
     upstream_url: "{{ am_util_url }}/v1/consumer/mobile_device_openrap/credential/register"

--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -3198,7 +3198,7 @@ kong_apis:
     - "{{ statsd_pulgin }}"
     - name: acl
       config.whitelist:
-        - 'mobileAdmin'
+        - 'portalAdmin'
     - name: rate-limiting
       config.policy: local
       config.hour: "{{ medium_rate_limit_per_hour }}"

--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -3593,6 +3593,7 @@ kong_apis:
       config.limit_by: ip
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
+
   - name: searchOrg
     uris: "{{ org_service_prefix }}/v1/search"
     upstream_url: "{{ learning_service_url }}/v1/org/search"

--- a/ansible/roles/kong-consumer/defaults/main.yml
+++ b/ansible/roles/kong-consumer/defaults/main.yml
@@ -103,3 +103,6 @@ kong_consumers:
   - username: mobile_devicev2
     groups: "{{ mobile_device_groups }}"
     state: present
+  - username: portalv2
+    groups: "{{ kong_all_consumer_groups }}"
+    state: present

--- a/ansible/roles/kong-consumer/defaults/main.yml
+++ b/ansible/roles/kong-consumer/defaults/main.yml
@@ -7,6 +7,9 @@ mobile_admin_groups:
 mobile_app_groups:
   - mobileAdmin
 
+potal_app_groups:
+  - portalAdmin
+
 mobile_device_groups:
   - appAccess
   - certificateAccess
@@ -102,6 +105,9 @@ kong_consumers:
     state: present
   - username: mobile_devicev2
     groups: "{{ mobile_device_groups }}"
+    state: present
+  - username: portal_app
+    groups: "{{ potal_app_groups }}"
     state: present
   - username: portalv2
     groups: "{{ kong_all_consumer_groups }}"

--- a/kubernetes/ansible/roles/helm-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/helm-deploy/defaults/main.yml
@@ -123,7 +123,7 @@ adminutil_keys_values:
 - key_to_register: portal
   values_to_pass:
     basepath: "/keys/"
-    keyprefix: "{{ adminutil_portal_keyprefix }}"
+    keyprefix: "{{ adminutil__portal_keyprefix }}"
     keystart: "{{ adminutil__portal_keystart }}"
     keycount: "{{ adminutil__portal_keycount|int }}"
   role_to_run:

--- a/kubernetes/ansible/roles/helm-deploy/defaults/main.yml
+++ b/kubernetes/ansible/roles/helm-deploy/defaults/main.yml
@@ -79,12 +79,15 @@ api_managerecho_liveness_readiness:
 adminutil__device_keyprefix: "device"
 adminutil__access_keyprefix: "access"
 adminutil__desktop_keyprefix: "desktop"
+adminutil_portal_keyprefix: "portal"
 adminutil__device_keystart: 0
 adminutil__device_keycount: 0
 adminutil__access_keystart: 0
 adminutil__access_keycount: 0
 adminutil__desktop_keystart: 0
 adminutil__desktop_keycount: 0
+adminutil__portal_keystart: 0
+adminutil__portal_keycount: 0
 
 adminutil_refresh_token_public_key_prefix: "refresh_token_public_key"
 adminutil_access_token_validity: 43200  # 12 hours access token validity
@@ -117,6 +120,12 @@ adminutil_keys_values:
     keyprefix: "{{ adminutil__desktop_keyprefix }}"
     keystart: "{{ adminutil__desktop_keystart }}"
     keycount: "{{ adminutil__desktop_keycount|int }}"
+- key_to_register: portal
+  values_to_pass:
+    basepath: "/keys/"
+    keyprefix: "{{ adminutil_portal_keyprefix }}"
+    keystart: "{{ adminutil__portal_keystart }}"
+    keycount: "{{ adminutil__portal_keycount|int }}"
   role_to_run:
     - decrypt.yml
     - copy-to-helm.yml

--- a/kubernetes/ansible/roles/kong-jwt-create-adminutil/defaults/main.yml
+++ b/kubernetes/ansible/roles/kong-jwt-create-adminutil/defaults/main.yml
@@ -6,6 +6,7 @@ kong_private_key_sign_incr: 1
 ## The below needs to be defined in private repo if you want to use this role ##
 #kong_mobile_v2_consumer: "device"
 #kong_desktop_v2_consumer: "desktop"
+#kong_portalv2_consumer: "portal"
 
 kong_mount_roles_values:
 - key_to_register: device
@@ -26,6 +27,17 @@ kong_mount_roles_values:
     keystart: "{{ adminutil__desktop_keystart }}"
     keycount: "{{ adminutil__desktop_keycount }}"
     kong_consumer: "{{ kong_desktop_v2_consumer }}"
+  role_to_run:
+    - decrypt.yml
+    - generate-keys.yml
+    - onboard-keys.yml
+- key_to_register: portal
+  values_to_pass:
+    basepath: "{{ kong_private_key_path }}"
+    keyprefix: "{{ adminutil_portal_keyprefix }}"
+    keystart: "{{ adminutil__portal_keystart }}"
+    keycount: "{{ adminutil__portal_keycount }}"
+    kong_consumer: "{{ kong_portalv2_consumer }}"
   role_to_run:
     - decrypt.yml
     - generate-keys.yml

--- a/kubernetes/ansible/roles/kong-jwt-create-adminutil/defaults/main.yml
+++ b/kubernetes/ansible/roles/kong-jwt-create-adminutil/defaults/main.yml
@@ -34,10 +34,10 @@ kong_mount_roles_values:
 - key_to_register: portal
   values_to_pass:
     basepath: "{{ kong_private_key_path }}"
-    keyprefix: "{{ adminutil_portal_keyprefix }}"
+    keyprefix: "{{ adminutil__portal_keyprefix }}"
     keystart: "{{ adminutil__portal_keystart }}"
     keycount: "{{ adminutil__portal_keycount }}"
-    kong_consumer: "{{ kong_portalv2_consumer }}"
+    kong_consumer: "{{ kong_portal_v2_consumer }}"
   role_to_run:
     - decrypt.yml
     - generate-keys.yml

--- a/kubernetes/helm_charts/core/adminutils/values.j2
+++ b/kubernetes/helm_charts/core/adminutils/values.j2
@@ -43,6 +43,10 @@ adminutilenv:
   AM_ADMIN_API_DESKTOP_DEVICE_KEYPREFIX: '"{{ adminutil__desktop_keyprefix }}"'
   AM_ADMIN_API_DESKTOP_DEVICE_KEYSTART: '"{{ adminutil__desktop_keystart }}"'
   AM_ADMIN_API_DESKTOP_DEVICE_KEYCOUNT: '"{{ adminutil__desktop_keycount }}"'
+  AM_ADMIN_API_PORTAL_BASEPATH: "/keys/"
+  AM_ADMIN_API_PORTAL_KEYPREFIX: '"{{ adminutil_portal_keyprefix }}"'
+  AM_ADMIN_API_PORTAL_KEYSTART: '"{{ adminutil__portal_keystart }}"'
+  AM_ADMIN_API_PORTAL_KEYCOUNT: '"{{ adminutil__portal_keycount }}"'
   AM_ADMIN_API_ACCESS_BASEPATH: "/keys/"
   AM_ADMIN_API_ACCESS_KEYPREFIX: '"{{ adminutil__access_keyprefix }}"'
   AM_ADMIN_API_ACCESS_KEYSTART: '"{{ adminutil__access_keystart }}"'

--- a/kubernetes/helm_charts/core/adminutils/values.j2
+++ b/kubernetes/helm_charts/core/adminutils/values.j2
@@ -34,7 +34,7 @@ adminutilenv:
   ENDPOINTS_HEALTH_SENSITIVE: '"{{adminutil__is_health_sensitive|default('false')}}"'
   ENDPOINTS_METRICS_ID: {{adminutil__metrics_id|default('metrics')}}
   ENDPOINTS_METRICS_SENSITIVE: '"{{adminutil__is_metrics_sensitive|default('false')}}"'
-  AM_ADMIN_API_KEYS: "mobile_device,desktop_device,access"
+  AM_ADMIN_API_KEYS: "mobile_device,desktop_device,portal,access"
   AM_ADMIN_API_MOBILE_DEVICE_BASEPATH: "/keys/"
   AM_ADMIN_API_MOBILE_DEVICE_KEYPREFIX: '"{{ adminutil__device_keyprefix }}"'
   AM_ADMIN_API_MOBILE_DEVICE_KEYSTART: '"{{ adminutil__device_keystart }}"'

--- a/kubernetes/helm_charts/core/adminutils/values.j2
+++ b/kubernetes/helm_charts/core/adminutils/values.j2
@@ -44,7 +44,7 @@ adminutilenv:
   AM_ADMIN_API_DESKTOP_DEVICE_KEYSTART: '"{{ adminutil__desktop_keystart }}"'
   AM_ADMIN_API_DESKTOP_DEVICE_KEYCOUNT: '"{{ adminutil__desktop_keycount }}"'
   AM_ADMIN_API_PORTAL_BASEPATH: "/keys/"
-  AM_ADMIN_API_PORTAL_KEYPREFIX: '"{{ adminutil_portal_keyprefix }}"'
+  AM_ADMIN_API_PORTAL_KEYPREFIX: '"{{ adminutil__portal_keyprefix }}"'
   AM_ADMIN_API_PORTAL_KEYSTART: '"{{ adminutil__portal_keystart }}"'
   AM_ADMIN_API_PORTAL_KEYCOUNT: '"{{ adminutil__portal_keycount }}"'
   AM_ADMIN_API_ACCESS_BASEPATH: "/keys/"


### PR DESCRIPTION
- New API, ACL for portal v2 endpoint
- New consumer for portal to register and request a token
- New variables, env to support the v2 endpoint
- Update kong onboarding jwt role to support the second consumer, commented defaults as a safety measure
- Adminutil code refrence - project-sunbird/sunbird-apimanager-util#11