### PR TITLE
Adding mail username as apikey

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+callback_whitelist = profile_tasks
+host_key_checking=False
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp

--- a/ansible/inventory/env/group_vars/all.yml
+++ b/ansible/inventory/env/group_vars/all.yml
@@ -660,3 +660,8 @@ dp_postgres_username: analytics
 
 # Will enable cassandra cluster if number of cassandra nodes > 1
 cassandra_cluster_size: "{{ groups['cassandra'] | length }}"
+
+# Azure sendgrid mail server apitoken username
+# This value is constant for sendgrid api authentication.
+# If you're using any other mail server provider, override this value in common.yaml.
+mail_server_username: "apikey"

--- a/kubernetes/ansible/ansible.cfg
+++ b/kubernetes/ansible/ansible.cfg
@@ -1,0 +1,6 @@
+[defaults]
+callback_whitelist = profile_tasks
+host_key_checking=False
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp


### PR DESCRIPTION
We're using azure sendgrid apis and the usename is same
"apikey" for ever. So moving it to all.yaml. Anybody can override this with own variable.