### PR TITLE
fix: do not run schema updates on all nodes

### DIFF
--- a/ansible/roles/cassandra-db-update/tasks/main.yml
+++ b/ansible/roles/cassandra-db-update/tasks/main.yml
@@ -12,6 +12,7 @@
     src: "{{cql_file}}"
     dest: "/tmp/{{cql_file}}"
     mode: 0755
+  run_once: true
   
 - name: run cql 
   become: yes
@@ -19,10 +20,11 @@
   async: 3600
   poll: 10
   ignore_errors: true
+  run_once: true
 
 - name: remove cql file
   become: yes
   file:
     path: "/tmp/{{cql_file}}"
     state: absent
-
+  run_once: true


### PR DESCRIPTION
• Cassandra sends the schema updates to other nodes so its not required to run on all nodes
• Sometimes running on all nodes causes instability if schema update is not propogated and another node concurrently tries to update the schema