### PR TITLE
Updated link for Installation wiki

### DIFF
--- a/Installation.md
+++ b/Installation.md
@@ -1,1 +1,1 @@
-### Installation wiki moved to [here.](http://www.sunbird.org/developer-docs/installation) 
+### Installation wiki moved to [here.](http://docs.sunbird.org/latest/developer-docs/server-installation/prerequisites/) 


### PR DESCRIPTION
previous link was redirecting to page 404.
![image](https://user-images.githubusercontent.com/38539637/111916205-cab19180-8a9f-11eb-927e-5d2bc07bc94f.png)
