### PR TITLE
feat: TG-884 verify using HS256 token for keycloak 7

### DIFF
--- a/kubernetes/helm_charts/core/adminutils/values.j2
+++ b/kubernetes/helm_charts/core/adminutils/values.j2
@@ -55,6 +55,7 @@ adminutilenv:
   REFRESH_TOKEN_PUBLIC_BASEPATH: "/keys/"
   REFRESH_TOKEN_PUBLIC_KEYPREFIX: '"{{ adminutil_refresh_token_public_key_prefix }}"'
   REFRESH_TOKEN_KID: '"{{ adminutil_refresh_token_public_key_kid }}"'
+  REFRESH_TOKEN_SECRET_KEY: '"{{ adminutil_refresh_token_secret_key }}"'
   REFRESH_TOKEN_DOMAIN: '"{{ keycloak_auth_server_url }}/realms/{{ keycloak_realm }}"'
   REFRESH_TOKEN_PRELOAD: '"{{ adminutil_refresh_token_preload }}"'
   ACCESS_TOKEN_VALIDITY: '"{{ adminutil_access_token_validity }}"'

--- a/private_repo/ansible/inventory/dev/Core/secrets.yml
+++ b/private_repo/ansible/inventory/dev/Core/secrets.yml
@@ -88,7 +88,9 @@ mongodb_keyfile_content: |
 # use below command to use a random password
 # 'openssl rand -hex 10'
 nodebb_admin_password:
-adminutil_refresh_token_public_key_kid: ""   #get after eycloak deployment using lms client
+adminutil_refresh_token_public_key_kid: ""   # get after Keycloak deployment using lms client
+#SELECT value FROM component_config CC INNER JOIN component C ON(CC.component_id = C.id) WHERE C.realm_id = 'sunbird' and provider_id = 'hmac-generated' AND CC.name = 'secret';
+adminutil_refresh_token_secret_key: ""  # get after Keycloak deployment from postgres using the above query
 
 # Steps to generating the Nodebb auth token
 # 1. Login to Nodebb (https://<domain-name>/discussions/login) as a Admin.


### PR DESCRIPTION
 - Since keycloak 4.5.0, refresh tokens are signed using HS256 algorithm 
 - Reference https://issues.redhat.com/browse/KEYCLOAK-4622 
 - Adminutils PR reference - https://github.com/project-sunbird/sunbird-apimanager-util/pull/15