### PR TITLE
fix: TG-911 nginx logs parsing for CRI-O"

### DIFF
--- a/kubernetes/helm_charts/logging/fluent-bit/templates/configMap.yaml
+++ b/kubernetes/helm_charts/logging/fluent-bit/templates/configMap.yaml
@@ -31,11 +31,33 @@ data:
         # annotaions:
         #   fluentbit.io/exclude: true
         K8S-Logging.Exclude On
+
     [FILTER]
         # Discard all health debug and info logs
         Name grep
         Match kube.*
         exclude message /^.*(?:debug|info|GET (\/service)?\/health).*$
+
+    [FILTER]
+        Name          nest
+        Match         kube.*
+        Operation     lift
+        Nested_under  kubernetes
+        Add_prefix    kubernetes_
+
+    [FILTER]
+        Name          nest
+        Match         kube.*
+        Operation     lift
+        Nested_under  kubernetes_labels
+        Add_prefix    kubernetes_labels_
+
+   [FILTER]
+        Name          nest
+        Match         kube.*
+        Operation     lift
+        Nested_under  kubernetes_annotations
+        Add_prefix    kubernetes_annotations_
 
   fluent-bit.conf: |
     [SERVICE]
@@ -61,7 +83,7 @@ data:
         Name              tail
         Tag               kube.*
         Path              /var/log/containers/*.log
-        Parser            docker
+        Parser            cri
         DB                /mnt/log/flb_kube.db
         Mem_Buf_Limit     120MB
         # Set the initial buffer size to read files data.
@@ -138,6 +160,14 @@ data:
         Time_Key    time
         Time_Format %Y-%m-%dT%H:%M:%S.%L
         Time_Keep   On
+
+    [PARSER]
+        Name        cri
+        Format      regex
+        Regex       ^(?<time>[^ ]+) (?<stream>stdout|stderr) (?<logtag>[^ ]*) (?<log>.*)$
+        Time_Key    time
+        Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+
     [PARSER]
         Name        nginx2
         Format      regex
@@ -153,11 +183,11 @@ data:
         Regex       ^\<(?<pri>[0-9]+)\>(?<time>[^ ]* {1,2}[^ ]* [^ ]*) (?<host>[^ ]*) (?<ident>[a-zA-Z0-9_\/\.\-]*)(?:\[(?<pid>[0-9]+)\])?(?:[^\:]*\:)? *(?<message>.*)$
         Time_Key    time
         Time_Format %b %d %H:%M:%S
+
     [PARSER]
         Name    catchall
         Format  regex
         Regex   ^(?<message>.*)$
-
 kind: ConfigMap
 metadata:
   name: fluent-bit-config


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
- Current nginx logs parsing does not work with CRI-O
- Daemon dockerd is deprecated
- The current change will not work with kubernetes running on dockerd
- All kibana `.` notations are replaced with `_` notations 
- Example: 
  - Previously - `kubernetes.labels.app`
  - New - `kubernetes_labels_app`

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested in local k3d cluster with EFK running on containerd
- [x] Verified fields are preset in ES mapping and Kibana UI

**Test Configuration**:
* Software versions: `Kubernetes 1.19.4`, `k3d version v3.4.0`, `k3s version v1.19.4-k3s1`

### Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules