### PR TITLE
fix: dont skip tag creation for nodebb for same commit

### DIFF
--- a/pipelines/release/Jenkinsfile.hotfix.rc.tag
+++ b/pipelines/release/Jenkinsfile.hotfix.rc.tag
@@ -88,7 +88,7 @@ node {
                                 }
                                 else {
                                     returnCode = sh(script: "git diff --exit-code refs/remotes/origin/${params.release_branch} tags/$tagRefBranch > /dev/null", returnStatus: true)
-                                    if (returnCode == 0) {
+                                    if (returnCode == 0 && repo != "project-sunbird/sunbird-nodebb") {
                                         println(ANSI_BOLD + ANSI_GREEN + "No commit changes found. Skipping creating tag" + ANSI_NORMAL)
                                         tagName = tagRefBranch
                                     }

--- a/pipelines/release/Jenkinsfile.staging.rc.tag
+++ b/pipelines/release/Jenkinsfile.staging.rc.tag
@@ -81,7 +81,7 @@ node {
                                 }
                                 else {
                                     returnCode = sh(script: "git diff --exit-code refs/remotes/origin/${params.release_branch} tags/$tagRefBranch > /dev/null", returnStatus: true)
-                                    if (returnCode == 0) {
+                                    if (returnCode == 0 && repo != "project-sunbird/sunbird-nodebb") {
                                         println(ANSI_BOLD + ANSI_GREEN + "No commit changes found. Skipping creating tag" + ANSI_NORMAL)
                                         tagName = tagRefBranch
                                     }


### PR DESCRIPTION
- As there will be no new commits for NodeBB repo (only upstream commits), we will create a new tag is created for same hash