### PR TITLE
feat: TG-957 option to use graylog behind a private LB with Oauth

### DIFF
--- a/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
+++ b/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
@@ -8,13 +8,7 @@ config:
 {% else %}
     redirect_url = "{{ oauth2_proxy_redirect_url }}"
 {% endif %}
-{% if send_logs_to_graylog is defined and send_logs_to_graylog is true %}
-    upstreams = "http://graylog.logging.svc.cluster.local"
-{% else %}
-    upstreams = "http://{{ kibana_service }}"
-{% endif %}
     email_domains = {{ kibana_oauth_authenticated_email_domains_kube }}
-    authenticated_emails_file = "/etc/oauth2/auth-emails/authenticated_email.txt"
     cookie_expire = "24h"
     cookie_refresh = "4h"
 {% if (graylog_open_to_public is defined and graylog_open_to_public is true) or (send_logs_to_graylog is not defined or send_logs_to_graylog is false) %}
@@ -27,9 +21,45 @@ config:
     silence_ping_logging = true
     skip_provider_button = true
 
+alphaConfigFile:
+  upstreams:
+  - flushInterval: 1s
+    id: /
+    passHostHeader: true
+    path: /
+    proxyWebSockets: true
+{% if send_logs_to_graylog is defined and send_logs_to_graylog is true %}
+    uri: "http://graylog.logging.svc.cluster.local"
+{% else %}
+    uri: "http://{{ kibana_service }}"
+{% endif %}
+  server:
+    BindAddress: 0.0.0.0:4180
+  injectRequestHeaders:
+  - name: X-Forwarded-Groups
+    values:
+    - claim: groups
+  - name: X-Forwarded-User
+    values:
+    - claim: user
+  - name: X-Forwarded-Email
+    values:
+    - claim: email
+  - name: X-Forwarded-Preferred-Username
+    values:
+    - claim: preferred_username
+{% if (graylog_open_to_public is not defined or graylog_open_to_public is false) and (send_logs_to_graylog is defined and send_logs_to_graylog is true) and (graylog_open_to_private is defined and graylog_open_to_private is true) %}
+  - name: Graylog-User
+    values:
+    - value: "{{ viewer | b64encode }}"
+  - name: X-Graylog-Server-URL
+    values:
+    - value: "{{ http://{{ oauth2_proxy_lb_ip }}.nip.io | b64encode }}"
+{% endif %}
+
 image:
   repository: "quay.io/oauth2-proxy/oauth2-proxy"
-  tag: "v7.1.2"
+  tag: "v7.1.3"
   pullPolicy: "IfNotPresent"
 
 replicaCount: {{ oauth2_replicas | default(1) }}

--- a/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
+++ b/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
@@ -3,12 +3,12 @@ config:
   clientSecret: "{{ google_client_secret }}"
   cookieSecret: "{{ cookie_secret }}"
   configFile: |-
-{% if graylog_open_to_public is false %}
+{% if (graylog_open_to_public is not defined or graylog_open_to_public is false) and (send_logs_to_graylog is defined and send_logs_to_graylog is true) and (graylog_open_to_private is defined and graylog_open_to_private is true) %}
     redirect_url = "http://{{ oauth2_proxy_lb_ip }}.nip.io/oauth2/callback"
 {% else %}
     redirect_url = "{{ oauth2_proxy_redirect_url }}"
 {% endif %}
-{% if graylog_open_to_public is true %}
+{% if send_logs_to_graylog is defined and send_logs_to_graylog is true %}
     upstreams = "http://graylog.logging.svc.cluster.local"
 {% else %}
     upstreams = "http://{{ kibana_service }}"
@@ -17,9 +17,12 @@ config:
     authenticated_emails_file = "/etc/oauth2/auth-emails/authenticated_email.txt"
     cookie_expire = "24h"
     cookie_refresh = "4h"
-{% if graylog_open_to_public is false %}
+{% if (graylog_open_to_public is defined and graylog_open_to_public is true) or (send_logs_to_graylog is not defined or send_logs_to_graylog is false) %}
     cookie_secure = true
     cookie_httponly = true
+{% else %}
+    cookie_secure = false
+    cookie_httponly = false
 {% endif %}
     silence_ping_logging = true
     skip_provider_button = true
@@ -48,7 +51,7 @@ authenticatedEmailsFile:
 
 fullnameOverride: "oauth2-proxy"
 
-{% if graylog_open_to_public is false %}
+{% if (graylog_open_to_public is not defined or graylog_open_to_public is false) and (send_logs_to_graylog is defined and send_logs_to_graylog is true) and (graylog_open_to_private is defined and graylog_open_to_private is true) %}
 service:
   type: LoadBalancer
   loadBalancerIP: {{ oauth2_proxy_lb_ip }}

--- a/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
+++ b/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
@@ -3,7 +3,11 @@ config:
   clientSecret: "{{ google_client_secret }}"
   cookieSecret: "{{ cookie_secret }}"
   configFile: |-
+{% if graylog_open_to_public is false %}
+    redirect_url = "http://{{ oauth2_proxy_lb_ip }}.nip.io/oauth2/callback"
+{% else %}
     redirect_url = "{{ oauth2_proxy_redirect_url }}"
+{% endif %}
 {% if graylog_open_to_public is true %}
     upstreams = "http://graylog.logging.svc.cluster.local"
 {% else %}
@@ -13,8 +17,10 @@ config:
     authenticated_emails_file = "/etc/oauth2/auth-emails/authenticated_email.txt"
     cookie_expire = "24h"
     cookie_refresh = "4h"
+{% if graylog_open_to_public is false %}
     cookie_secure = true
     cookie_httponly = true
+{% endif %}
     silence_ping_logging = true
     skip_provider_button = true
 
@@ -41,3 +47,20 @@ authenticatedEmailsFile:
      {% endfor %}
 
 fullnameOverride: "oauth2-proxy"
+
+{% if graylog_open_to_public is false %}
+service:
+  type: LoadBalancer
+  loadBalancerIP: {{ oauth2_proxy_lb_ip }}
+  port: 80
+{% if nginx_private_ingress_annotations is defined and nginx_private_ingress_annotations %}
+# you can define annotations in ansible for custom behaviour
+# eg:
+# nginx_private_ingress_annotations:
+#   cloud.google.com/load-balancer-type: "Internal"
+  annotations: {{nginx_private_ingress_annotations|to_json}}
+{% else %}
+  annotations:
+    cloud_provider: 'service.beta.kubernetes.io/azure-load-balancer-internal: "true"'
+{% endif %}
+{% endif %}

--- a/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
+++ b/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
@@ -90,14 +90,5 @@ service:
   type: LoadBalancer
   loadBalancerIP: {{ oauth2_proxy_lb_ip }}
   port: 80
-{% if nginx_private_ingress_annotations is defined and nginx_private_ingress_annotations %}
-# you can define annotations in ansible for custom behaviour
-# eg:
-# nginx_private_ingress_annotations:
-#   cloud.google.com/load-balancer-type: "Internal"
-  annotations: {{nginx_private_ingress_annotations|to_json}}
-{% else %}
-  annotations:
-    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
-{% endif %}
+  annotations: {{ nginx_private_ingress_annotations|to_json }}
 {% endif %}

--- a/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
+++ b/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
@@ -28,8 +28,8 @@ config:
     skip_provider_button = true
 
 image:
-  repository: "sunbird/oauth2_proxy"
-  tag: "v1.0"
+  repository: "quay.io/oauth2-proxy/oauth2-proxy"
+  tag: "v7.1.2"
   pullPolicy: "IfNotPresent"
 
 replicaCount: {{ oauth2_replicas | default(1) }}

--- a/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
+++ b/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
@@ -64,6 +64,6 @@ service:
   annotations: {{nginx_private_ingress_annotations|to_json}}
 {% else %}
   annotations:
-    cloud_provider: 'service.beta.kubernetes.io/azure-load-balancer-internal: "true"'
+    service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 {% endif %}
 {% endif %}

--- a/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
+++ b/kubernetes/ansible/roles/logging/templates/oauth2-proxy.yaml
@@ -1,6 +1,4 @@
 config:
-  clientID: "{{ google_client_id }}"
-  clientSecret: "{{ google_client_secret }}"
   cookieSecret: "{{ cookie_secret }}"
   configFile: |-
 {% if (graylog_open_to_public is not defined or graylog_open_to_public is false) and (send_logs_to_graylog is defined and send_logs_to_graylog is true) and (graylog_open_to_private is defined and graylog_open_to_private is true) %}
@@ -21,40 +19,46 @@ config:
     silence_ping_logging = true
     skip_provider_button = true
 
-alphaConfigFile:
-  upstreams:
-  - flushInterval: 1s
-    id: /
-    passHostHeader: true
-    path: /
-    proxyWebSockets: true
+  alphaConfigFile: |-
+    server:
+      BindAddress: 0.0.0.0:4180
+    providers:
+    - approvalPrompt: force
+      clientID: "{{ google_client_id }}"
+      clientSecret: "{{ google_client_secret }}"
+      id: "google={{ google_client_id }}"
+      provider: google
+    upstreams:
+    - flushInterval: 1s
+      id: /
+      passHostHeader: true
+      path: /
+      proxyWebSockets: true
 {% if send_logs_to_graylog is defined and send_logs_to_graylog is true %}
-    uri: "http://graylog.logging.svc.cluster.local"
+      uri: "http://graylog.logging.svc.cluster.local"
 {% else %}
-    uri: "http://{{ kibana_service }}"
+      uri: "http://{{ kibana_service }}"
 {% endif %}
-  server:
-    BindAddress: 0.0.0.0:4180
-  injectRequestHeaders:
-  - name: X-Forwarded-Groups
-    values:
-    - claim: groups
-  - name: X-Forwarded-User
-    values:
-    - claim: user
-  - name: X-Forwarded-Email
-    values:
-    - claim: email
-  - name: X-Forwarded-Preferred-Username
-    values:
-    - claim: preferred_username
+    injectRequestHeaders:
+    - name: X-Forwarded-Groups
+      values:
+      - claim: groups
+    - name: X-Forwarded-User
+      values:
+      - claim: user
+    - name: X-Forwarded-Email
+      values:
+      - claim: email
+    - name: X-Forwarded-Preferred-Username
+      values:
+      - claim: preferred_username
 {% if (graylog_open_to_public is not defined or graylog_open_to_public is false) and (send_logs_to_graylog is defined and send_logs_to_graylog is true) and (graylog_open_to_private is defined and graylog_open_to_private is true) %}
-  - name: Graylog-User
-    values:
-    - value: "{{ viewer | b64encode }}"
-  - name: X-Graylog-Server-URL
-    values:
-    - value: "{{ http://{{ oauth2_proxy_lb_ip }}.nip.io | b64encode }}"
+    - name: Graylog-User
+      values:
+      - value: "{{ graylog_auto_login_user | default('viewer') | b64encode }}"
+    - name: X-Graylog-Server-URL
+      values:
+      - value: "{{ graylog_proxy_server_url | default('http://{{ oauth2_proxy_lb_ip }}.nip.io') | b64encode }}"
 {% endif %}
 
 image:

--- a/kubernetes/helm_charts/logging/oauth2-proxy/templates/configmap.yaml
+++ b/kubernetes/helm_charts/logging/oauth2-proxy/templates/configmap.yaml
@@ -12,4 +12,19 @@ metadata:
 data:
   oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}
 {{- end }}
+
+---
+{{- if .Values.config.alphaConfigFile }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    app: {{ template "oauth2-proxy.name" . }}
+    chart: {{ template "oauth2-proxy.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "oauth2-proxy.fullname" . }}
+data:
+  oauth2_proxy.yaml: {{ .Values.config.configFile | quote }}
+{{- end }}
 {{- end }}

--- a/kubernetes/helm_charts/logging/oauth2-proxy/templates/configmap.yaml
+++ b/kubernetes/helm_charts/logging/oauth2-proxy/templates/configmap.yaml
@@ -11,20 +11,9 @@ metadata:
   name: {{ template "oauth2-proxy.fullname" . }}
 data:
   oauth2_proxy.cfg: {{ .Values.config.configFile | quote }}
-{{- end }}
 
----
 {{- if .Values.config.alphaConfigFile }}
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  labels:
-    app: {{ template "oauth2-proxy.name" . }}
-    chart: {{ template "oauth2-proxy.chart" . }}
-    heritage: {{ .Release.Service }}
-    release: {{ .Release.Name }}
-  name: {{ template "oauth2-proxy.fullname" . }}
-data:
-  oauth2_proxy.yaml: {{ .Values.config.configFile | quote }}
+  oauth2_proxy.yaml: {{ .Values.config.alphaConfigFile | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/kubernetes/helm_charts/logging/oauth2-proxy/templates/deployment.yaml
+++ b/kubernetes/helm_charts/logging/oauth2-proxy/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
-          - --http-address=0.0.0.0:4180
         {{- range $key, $value := .Values.extraArgs }}
           {{- if $value }}
           - --{{ $key }}={{ $value }}
@@ -51,6 +50,9 @@ spec:
         {{- end }}
         {{- if or .Values.config.existingConfig .Values.config.configFile }}
           - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
+        {{- end }}
+        {{- if or .Values.config.existingConfig .Values.config.alphaConfigFile }}
+          - --config=/etc/oauth2_proxy_alpha/oauth2_proxy.yaml
         {{- end }}
         {{- if .Values.authenticatedEmailsFile.enabled }}
         {{- if .Values.authenticatedEmailsFile.template }}
@@ -127,6 +129,10 @@ spec:
         - mountPath: /etc/oauth2_proxy
           name: configmain
 {{- end }}
+{{- if or .Values.config.existingConfig .Values.config.alphaConfigFile }}
+        - mountPath: /etc/oauth2_proxy_alpha
+          name: configalpha
+{{- end }}
 {{- if .Values.authenticatedEmailsFile.enabled }}
         - mountPath: /etc/oauth2-proxy
           name: configaccesslist
@@ -164,6 +170,12 @@ spec:
           defaultMode: 420
           name: {{ if .Values.config.existingConfig }}{{ .Values.config.existingConfig }}{{ else }}{{ template "oauth2-proxy.fullname" . }}{{ end }}
         name: configmain
+{{- end }}
+{{- if or .Values.config.existingConfig .Values.config.alphaConfigFile }}
+      - configMap:
+          defaultMode: 420
+          name: {{ if .Values.config.existingConfig }}{{ .Values.config.existingConfig | join "-alpha" }}{{ else }}{{ template "oauth2-proxy.fullname" . | join "-alpha" }}{{ end }}
+        name: configalpha
 {{- end }}
 {{- if ne (len .Values.extraVolumes) 0 }}
 {{ toYaml .Values.extraVolumes | indent 6 }}

--- a/kubernetes/helm_charts/logging/oauth2-proxy/templates/deployment.yaml
+++ b/kubernetes/helm_charts/logging/oauth2-proxy/templates/deployment.yaml
@@ -52,7 +52,7 @@ spec:
           - --config=/etc/oauth2_proxy/oauth2_proxy.cfg
         {{- end }}
         {{- if or .Values.config.existingConfig .Values.config.alphaConfigFile }}
-          - --config=/etc/oauth2_proxy_alpha/oauth2_proxy.yaml
+          - --alpha-config=/etc/oauth2_proxy/oauth2_proxy.yaml
         {{- end }}
         {{- if .Values.authenticatedEmailsFile.enabled }}
         {{- if .Values.authenticatedEmailsFile.template }}
@@ -72,16 +72,6 @@ spec:
         {{- end }}
         {{- if .Values.proxyVarsAsSecrets }}
         env:
-        - name: OAUTH2_PROXY_CLIENT_ID
-          valueFrom:
-            secretKeyRef:
-              name:  {{ template "oauth2-proxy.secretName" . }}
-              key: client-id
-        - name: OAUTH2_PROXY_CLIENT_SECRET
-          valueFrom:
-            secretKeyRef:
-              name:  {{ template "oauth2-proxy.secretName" . }}
-              key: client-secret
         - name: OAUTH2_PROXY_COOKIE_SECRET
           valueFrom:
             secretKeyRef:
@@ -129,10 +119,6 @@ spec:
         - mountPath: /etc/oauth2_proxy
           name: configmain
 {{- end }}
-{{- if or .Values.config.existingConfig .Values.config.alphaConfigFile }}
-        - mountPath: /etc/oauth2_proxy_alpha
-          name: configalpha
-{{- end }}
 {{- if .Values.authenticatedEmailsFile.enabled }}
         - mountPath: /etc/oauth2-proxy
           name: configaccesslist
@@ -170,12 +156,6 @@ spec:
           defaultMode: 420
           name: {{ if .Values.config.existingConfig }}{{ .Values.config.existingConfig }}{{ else }}{{ template "oauth2-proxy.fullname" . }}{{ end }}
         name: configmain
-{{- end }}
-{{- if or .Values.config.existingConfig .Values.config.alphaConfigFile }}
-      - configMap:
-          defaultMode: 420
-          name: {{ if .Values.config.existingConfig }}{{ .Values.config.existingConfig | join "-alpha" }}{{ else }}{{ template "oauth2-proxy.fullname" . | join "-alpha" }}{{ end }}
-        name: configalpha
 {{- end }}
 {{- if ne (len .Values.extraVolumes) 0 }}
 {{ toYaml .Values.extraVolumes | indent 6 }}

--- a/kubernetes/helm_charts/logging/oauth2-proxy/templates/secret.yaml
+++ b/kubernetes/helm_charts/logging/oauth2-proxy/templates/secret.yaml
@@ -11,6 +11,4 @@ metadata:
 type: Opaque
 data:
   cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
-  client-secret: {{ .Values.config.clientSecret | b64enc | quote }}
-  client-id: {{ .Values.config.clientID | b64enc | quote }}
 {{- end -}}

--- a/kubernetes/helm_charts/logging/oauth2-proxy/values.yaml
+++ b/kubernetes/helm_charts/logging/oauth2-proxy/values.yaml
@@ -28,6 +28,8 @@ config:
   # Example:
   # existingConfig: config
 
+alphaConfigFile: {}
+
 image:
   repository: "quay.io/pusher/oauth2_proxy"
   tag: "v5.1.0"

--- a/kubernetes/helm_charts/logging/oauth2-proxy/values.yaml
+++ b/kubernetes/helm_charts/logging/oauth2-proxy/values.yaml
@@ -27,8 +27,7 @@ config:
   # Use an existing config map (see configmap.yaml for required fields)
   # Example:
   # existingConfig: config
-
-alphaConfigFile: {}
+  alphaConfigFile: {}
 
 image:
   repository: "quay.io/pusher/oauth2_proxy"


### PR DESCRIPTION
`send_logs_to_graylog` defines if the logs need to be sent to graylog or elasticsearch (EFK stack)
`graylog_open_to_public` defines whether graylog is accessible via domain
`graylog_open_to_private` defines if graylog needs to accessed only via internal network via a private LB
Using the above 3 variables, you can get exactly what you want

Below are some sensible scenarios -
1. You want the EFK stack. Don't define any of the above 3 variables
2. You just want graylog, you dont care how you will check the logs (tunneling maybe). In this case just set  `send_logs_to_graylog: true`
3. You want graylog to be available via domain, then set `graylog_open_to_public: true` along with `send_logs_to_graylog: true`
4. You want graylog but you want to access it only via private LB, then set `graylog_open_to_private: true` and `send_logs_to_graylog: true`
5. You made a blunder and set all of them as `graylog_open_to_private: true`, `graylog_open_to_public: true`, `send_logs_to_graylog: true`. In this case you will end up with `Scenario 3`
6. For private LB, you need to pre-define a private ip in your private repo using the variable `oauth2_proxy_lb_ip`. This is a pre-requisite so we can template the `redirect_url` with `oauth2_proxy_lb_ip.nip.io`
7. Ensure you add the `http://oauth2_proxy_lb_ip.nip.io` in google oauth admin console as a whitelisted URI and a valid redirect as `http://oauth2_proxy_lb_ip.nip.io/oauth2/callback`