### PR TITLE
fix: passing comma separated values from jenkins needs split filter

### DIFF
--- a/ansible/roles/graylog-mongodb-import/tasks/main.yml
+++ b/ansible/roles/graylog-mongodb-import/tasks/main.yml
@@ -7,19 +7,19 @@
     src: "{{ item }}.json"
     dest: "{{ mongo_json_data }}"
   with_items:
-  - "{{ graylog_mongo_collections }}"
+  - "{{ graylog_mongo_collections.split(',') }}"
 
 - name: drop and restore the data to mongodb
   shell: "mongoimport --drop --db={{ graylog_mongo_db }} --collection={{ item }} --file={{ mongo_json_data }}/{{ item }}.json"
   when: graylog_mongo_collections_drop is true
   with_items:
-  - "{{ graylog_mongo_collections }}"
+  - "{{ graylog_mongo_collections.split(',')  }}"
 
 - name: restore the data to mongodb
   shell: "mongoimport --db={{ graylog_mongo_db }} --collection={{ item }} --file={{ mongo_json_data }}/{{ item }}.json"
   when: graylog_mongo_collections_drop is false
   with_items:
-  - "{{ graylog_mongo_collections }}"
+  - "{{ graylog_mongo_collections.split(',')  }}"
 
 - name: clean up
   file:


### PR DESCRIPTION
- The comma separated parameter from jenkins in order to become a list needs a split filter