### PR TITLE
Issue #SB-26129 fix: App icon is stored as google drive url link on reading content in dock.

### DIFF
--- a/ansible/roles/stack-sunbird/templates/content-service_application.conf
+++ b/ansible/roles/stack-sunbird/templates/content-service_application.conf
@@ -479,6 +479,8 @@ azure_storage_key: "{{ sunbird_public_storage_account_name }}"
 azure_storage_secret: "{{ sunbird_public_storage_account_key }}"
 azure_storage_container: "{{ sunbird_content_azure_storage_container }}"
 
+learning_content_drive_apiKey: "{{learning_content_drive_apiKey}}"
+
 kafka {
   urls : "{{ kafka_urls }}"
   topic.send.enable : true


### PR DESCRIPTION
Issue #SB-26129 fix: App icon is stored as google drive url link on reading content in dock.

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Ran Unit Tests

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
