### PR TITLE
Revert "Issue #SB-26264 fix: Google Drive API appName config update"

### DIFF
--- a/ansible/roles/stack-sunbird/templates/content-service_application.conf
+++ b/ansible/roles/stack-sunbird/templates/content-service_application.conf
@@ -480,7 +480,6 @@ azure_storage_secret: "{{ sunbird_public_storage_account_key }}"
 azure_storage_container: "{{ sunbird_content_azure_storage_container }}"
 
 # Google Drive APIKEY
-learning_content_drive_appName = "{{ learning_content_drive_appName }}"
 learning_content_drive_apiKey = "{{ learning_content_drive_apiKey }}"
 
 kafka {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26264" title="SB-26264" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-26264</a>  Bulk upload is stuck when bulk upload is done with non google drive url for app icon.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reverts project-sunbird/sunbird-devops#2826