### PR TITLE
Single pane dashaboard for monitoring all services.

### DIFF
--- a/deploy/jenkins/jobs/Deploy/jobs/dev/jobs/Kubernetes/jobs/Monitoring/config.xml
+++ b/deploy/jenkins/jobs/Deploy/jobs/dev/jobs/Kubernetes/jobs/Monitoring/config.xml
@@ -80,7 +80,7 @@ return """&lt;b&gt;This parameter is not used&lt;/b&gt;"""</script>
         </org.biouno.unochoice.DynamicReferenceParameter>
         <hudson.model.StringParameterDefinition>
           <name>tag</name>
-          <description>&lt;font color=dimgray size=2&gt;&lt;b&gt;Please use "dashboards" as tag if you want to install/update the grafana dashboards. Choose all for full stack deployment&lt;/b&gt;&lt;/font&gt;</description>
+          <description>&lt;font color=dimgray size=2&gt;&lt;b&gt;Please use "dashboards" as tag if you want to install/update the grafana dashboards. Use "scrapeconfigs" to update the scrape targets. Choose all for full stack deployment&lt;/b&gt;&lt;/font&gt;</description>
           <defaultValue/>
           <trim>false</trim>
         </hudson.model.StringParameterDefinition>
@@ -95,7 +95,7 @@ return """&lt;b&gt;This parameter is not used&lt;/b&gt;"""</script>
       <limitOneJobWithMatchingParams>false</limitOneJobWithMatchingParams>
       <paramsToUseForLimit/>
     </hudson.plugins.throttleconcurrents.ThrottleJobProperty>
-    
+
     <org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>
       <triggers/>
     </org.jenkinsci.plugins.workflow.job.properties.PipelineTriggersJobProperty>

--- a/kubernetes/ansible/roles/sunbird-monitoring/tasks/main.yml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/tasks/main.yml
@@ -5,10 +5,18 @@
     src: "{{ item }}.yaml"
     dest: "/tmp/{{item}}.yaml"
   with_items: "{{ monitoring_stack + monitoring_stack_additional_charts }}"
+  tags:
+    - always
 
 - name: Creating sunbird monitoring stack
   shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} {{ item }} {{chart_path}}/{{ item }} --namespace monitoring -f /tmp/{{ item }}.yaml
   with_items: "{{ monitoring_stack + monitoring_stack_additional_charts }}"
+
+- name: Updating external monitoring targets
+  shell: helm upgrade --install --atomic --timeout {{helm_install_timeout | d("10m")}} {{ item }} {{chart_path}}/{{ item }} --namespace monitoring -f /tmp/{{ item }}.yaml
+  with_items: "additional-scrape-configs"
+  tags:
+    - scrapeconfigs
 
 - name: Creating sunbird monitoring grafana dashboards
   shell: "helm upgrade --install grafana-dashboards {{chart_path}}/dashboards --namespace monitoring"

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/additional-scrape-configs.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/additional-scrape-configs.yaml
@@ -1,7 +1,7 @@
-# This name is used to define the 
+# This name is used to define the
 # additionalScrapeConfigs name
 # {{ fullnameOverride }}-prometheus-scrape-confg
-# If you change this, make sure to update the value in 
+# If you change this, make sure to update the value in
 # additionalScrapeConfigs/defautls/main.yaml
 #}
 
@@ -52,13 +52,13 @@ scrapeconfig:
   - job_name: 'cassandra-exporter'
     metrics_path: /metrics
     static_configs:
-      - targets:  ["{{ groups['cassandra'] | difference(["localhost"]) | map('regex_replace', '^(.*)$', '\\1:8080' ) | list | join("\", \"") }}"] 
+      - targets:  ["{{ groups['cassandra'] | difference(["localhost"]) | map('regex_replace', '^(.*)$', '\\1:8080' ) | list | join("\", \"") }}"]
 
 {% if 'druid' in groups and groups['druid'] %}
   - job_name: 'druid-exporter'
     metrics_path: /metrics
     static_configs:
-      - targets:  ["{{ groups['druid'] | difference(["localhost"]) | map('regex_replace', '^(.*)$', '\\1:9108' ) | list | join("\", \"") }}"]  
+      - targets:  ["{{ groups['druid'] | difference(["localhost"]) | map('regex_replace', '^(.*)$', '\\1:9108' ) | list | join("\", \"") }}"]
 {% endif %}
 
   - job_name: 'redis_exporter_targets'
@@ -111,3 +111,24 @@ scrapeconfig:
       - target_label: __address__
         replacement: json-path-exporter.monitoring.svc.cluster.local:7979
         {% endfor %}
+
+namespace: "{{ namespace }}"
+services:
+  cassandra:
+    port: 9042
+    address: ["{{ groups['cassandra'] | join('","') }}"]
+  keycloak:
+    port: 8080
+    address: ["{{ groups['keycloak'] | join('","') }}"]
+  redis:
+    port: 6379
+    address: ["{{ groups['redis-cluster'] | join('","') }}"]
+  kafka:
+    port: 9092
+    address: ["{{ groups['kafka'] | join('","') }}"]
+  es:
+    port: 9200
+    address: ["{{ groups['es'] | join('","') }}"]
+  {% if additional_blackbox_scrapeconfigs is defined and additional_blackbox_scrapeconfigs %}
+  {{ additional_blackbox_scrapeconfigs | to_nice_yaml(indent=2) | indent( width=2) }}
+  {% endif %}

--- a/kubernetes/ansible/roles/sunbird-monitoring/templates/blackbox-exporter.yaml
+++ b/kubernetes/ansible/roles/sunbird-monitoring/templates/blackbox-exporter.yaml
@@ -1,0 +1,5 @@
+config:
+  modules:
+    tcp_connect:
+      prober: tcp
+      timeout: 5s

--- a/kubernetes/helm_charts/monitoring/additional-scrape-configs/templates/serviceMonitor.yaml
+++ b/kubernetes/helm_charts/monitoring/additional-scrape-configs/templates/serviceMonitor.yaml
@@ -1,0 +1,63 @@
+{{- range $k, $v := .Values.services }}
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ $k }}-external
+  namespace: {{ $.Values.namespace }}
+  labels:
+    app: {{ $k }}-external
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ $v.port }}
+    targetPort: {{ .port }}
+    name: app
+---
+kind: Endpoints
+apiVersion: v1
+metadata:
+  name: {{ $k }}-external
+  namespace: {{ $.Values.namespace }}
+subsets:
+- addresses:
+ {{- range $v.address }}
+  - ip: {{ . }}
+ {{- end }}
+  ports:
+  - name: app
+    port: {{ .port }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $k }}-external
+  namespace: {{ $.Values.namespace }}
+  labels:
+    release: prometheus-operator
+    app: {{ $k }}-external
+spec:
+  endpoints:
+  -
+    interval: {{ $.Values.scrapeInterval }}
+    path: {{ $.Values.scrapePath }}
+    port: app
+    scheme: http
+    scrapeTimeout: {{ $.Values.scrapeTimeout }}
+    relabelings:
+      - sourceLabels: [__address__]
+        targetLabel: __param_target
+      - sourceLabels: [__param_target]
+        targetLabel: instance
+      - targetLabel: __address__
+        replacement: {{ $.Values.blackboxExporterUrl }}:{{$.Values.blackboxExporterPort}}
+    params:
+      module:
+        - tcp_connect
+  namespaceSelector:
+    matchNames:
+    - {{ $.Values.namespace }}
+  selector:
+    matchLabels:
+      app: {{ $k }}-external
+{{- end }}

--- a/kubernetes/helm_charts/monitoring/additional-scrape-configs/values.yaml
+++ b/kubernetes/helm_charts/monitoring/additional-scrape-configs/values.yaml
@@ -8,3 +8,31 @@ scrapeconfig: []
   #       labels:
   #         "service_name": "druid"
 fullnameOverride: "sunbird-monitoring"
+
+#######################
+## Services to monitor
+#######################
+# services:
+#   cassandra:
+#     port: 9042
+#     address:
+#       - 10.20.10.1
+#       - 10.20.10.2
+#       - 10.20.10.3
+#       - 10.20.10.4
+#   neo4j:
+#     port: 7474
+#     address:
+#       - 10.10.10.1
+#       - 10.10.10.2
+#       - 10.10.10.3
+#       - 10.10.10.4
+services: {}
+
+namespace: "default"
+
+blackboxExporterUrl: blackbox-exporter-prometheus-blackbox-exporter.monitoring.svc.cluster.local
+blackboxExporterPort: 9115
+scrapeInterval: 15s
+scrapeTimeout: 10s
+scrapePath: "/probe"

--- a/kubernetes/helm_charts/monitoring/dashboards/dashboards/health.json
+++ b/kubernetes/helm_charts/monitoring/dashboards/dashboards/health.json
@@ -1,0 +1,297 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 158,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": true,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": null,
+          "fieldConfig": {
+            "defaults": {
+              "custom": {}
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 1
+          },
+          "hiddenSeries": false,
+          "id": 4,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "dataLinks": []
+          },
+          "percentage": false,
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "probe_success",
+              "interval": "",
+              "legendFormat": "{{service}} {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Health heuristics",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        }
+      ],
+      "title": "Health Heuristics",
+      "type": "row"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 6,
+      "panels": [],
+      "title": "Current Health Status",
+      "type": "row"
+    },
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "center",
+            "displayMode": "auto",
+            "filterable": false
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "dark-red",
+                  "index": 0,
+                  "text": "DOWN"
+                },
+                "1": {
+                  "color": "dark-green",
+                  "index": 1,
+                  "text": "UP"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.displayMode",
+                "value": "color-background"
+              },
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "from": "",
+                    "id": 0,
+                    "operator": "",
+                    "text": "DOWN",
+                    "to": "",
+                    "type": 1,
+                    "value": "0"
+                  },
+                  {
+                    "from": "",
+                    "id": 1,
+                    "operator": "",
+                    "text": "UP",
+                    "to": "",
+                    "type": 1,
+                    "value": "1"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 17,
+        "w": 24,
+        "x": 0,
+        "y": 2
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Value"
+          }
+        ]
+      },
+      "pluginVersion": "7.0.6",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "probe_success",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Service Health Overview",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "__name__": true,
+              "endpoint": true,
+              "job": true,
+              "namespace": true
+            },
+            "indexByName": {},
+            "renameByName": {
+              "Value": ""
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-5m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Health",
+  "uid": "QNgevzV7k",
+  "version": 7
+}

--- a/kubernetes/helm_charts/monitoring/dashboards/values.yaml
+++ b/kubernetes/helm_charts/monitoring/dashboards/values.yaml
@@ -395,6 +395,8 @@ dashboards1:
        file: dashboards/service-memory.json
      node-exporter:
        file: dashboards/node-exporter.json
+     health:
+       file: dashboards/health.json
 
 dashboards2:
    kong:
@@ -419,7 +421,7 @@ dashboards2:
        file: dashboards/hpa.json
    dashboardall:
      dashboard-all:
-       file: dashboards/dashboard-all.json 
+       file: dashboards/dashboard-all.json
 
   #   prometheus-stats:
   #     gnetId: 2


### PR DESCRIPTION
Create a dahsboard for all sevices to indicate whether they're healthy or not. Like a single pane of Glass.

## Implementation

As we're using prometheus operator as the default monitoring stack, I'm utilizing 
- ServiceMonitor
- Service
- Endpoint
Prometheus rewrite rules to manipulate the targets for blackbox exporter to manipulate.

By default a set of monitoring targets given in the [ansible](https://github.com/rjshrjndrn/sunbird-devops/blob/0a6c7ec3be51b234c0afef524bacede26464d8a7/kubernetes/ansible/roles/sunbird-monitoring/templates/additional-scrape-configs.yaml#L116).
For example,
```
services:
  cassandra:
    port: 9042
    address:
      - 10.20.10.1
      - 10.20.10.2
  neo4j:
    port: 7474
    address:
      - 10.10.10.1
```
You can add more services you want to monitor in your `common.yaml`  using,
```
additional_blackbox_scrapeconfigs:
    myExternalApp:
      port: 9092
      address:
        - ip1
        - ip2
```
Note: As of now it's only meant to be monitoring tcp port. This can be extended for all blackbox capabilities. As of not that's not the intent.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules