### PR TITLE
Issue #SB-26347 fix: enabling isCluster in redis db

### DIFF
--- a/ansible/roles/stack-sunbird/templates/sunbird_nodebb.env
+++ b/ansible/roles/stack-sunbird/templates/sunbird_nodebb.env
@@ -11,7 +11,7 @@ redis__username={{nodebb_db_username|default('')}}
 redis__password={{nodebb_db_password|default('')}}
 # redis database number
 redis__database={{nodebb_db_index_name|default(10)}}
-isCluster={{default(true)}}
+isCluster={{nodebb_cluster_enable|default(true)}}
 # password won't get overwritten if you run
 # 'node app --setup' multiple times
 # Default username is admin

--- a/ansible/roles/stack-sunbird/templates/sunbird_nodebb.env
+++ b/ansible/roles/stack-sunbird/templates/sunbird_nodebb.env
@@ -11,7 +11,7 @@ redis__username={{nodebb_db_username|default('')}}
 redis__password={{nodebb_db_password|default('')}}
 # redis database number
 redis__database={{nodebb_db_index_name|default(10)}}
-isCluster={{nodebb_cluster_enable|default(true)}}
+isCluster={{nodebb_cluster_enable|default('true')}}
 # password won't get overwritten if you run
 # 'node app --setup' multiple times
 # Default username is admin

--- a/ansible/roles/stack-sunbird/templates/sunbird_nodebb.env
+++ b/ansible/roles/stack-sunbird/templates/sunbird_nodebb.env
@@ -11,6 +11,7 @@ redis__username={{nodebb_db_username|default('')}}
 redis__password={{nodebb_db_password|default('')}}
 # redis database number
 redis__database={{nodebb_db_index_name|default(10)}}
+isCluster={{default(true)}}
 # password won't get overwritten if you run
 # 'node app --setup' multiple times
 # Default username is admin


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26347" title="SB-26347" target="_blank"><img alt="Task" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10318&avatarType=issuetype" />SB-26347</a>  Discussion Forum >> change the nodebb database from mongo to redis
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
