### PR TITLE
Revert "SB-25735 - consumption - Added kong-api entries for private read api's of content, collection, question, questionset and search"

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -349,25 +349,7 @@ kong_apis:
         - 'contentTempAccess'
     - name: rate-limiting
       config.policy: local
-      config.hour: "{{ medium_rate_limit_per_hour }}"
-      config.limit_by: credential
-    - name: request-size-limiting
-      config.allowed_payload_size: "{{ small_request_size_limit }}"
-
-  - name: compositePrivateSearch
-    uris: "{{ composite_service_prefix }}/v1/private/search"
-    upstream_url: "{{ knowledge_mw_service_url }}/v3/private/search"
-    strip_uri: true
-    plugins:
-    - name: jwt
-    - name: cors
-    - "{{ statsd_pulgin }}"
-    - name: acl
-      config.whitelist: 
-        - 'contentAdmin'
-    - name: rate-limiting
-      config.policy: local
-      config.hour: "{{ medium_rate_limit_per_hour }}"
+      config.hour: "{{ premium_consumer_large_rate_limit_per_hour }}"
       config.limit_by: credential
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
@@ -2227,24 +2209,6 @@ kong_apis:
       config.policy: local
       config.hour: "{{ medium_rate_limit_per_hour }}"
       config.limit_by: ip
-    - name: request-size-limiting
-      config.allowed_payload_size: "{{ small_request_size_limit }}"
-
-  - name: contentPrivateRead
-    uris: "{{ content_prefix }}/v1/private/read"
-    upstream_url: "{{ content_service_url }}/content/v4/private/read"
-    strip_uri: true
-    plugins:
-    - name: jwt
-    - name: cors
-    - "{{ statsd_pulgin }}"
-    - name: acl
-      config.whitelist:
-        - 'contentAccess'
-    - name: rate-limiting
-      config.policy: local
-      config.hour: "{{ medium_rate_limit_per_hour }}"
-      config.limit_by: credential
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
 
@@ -4870,24 +4834,6 @@ kong_apis:
     - name: request-size-limiting
       config.allowed_payload_size: "{{ medium_request_size_limit }}"
 
-  - name: collectionPrivateRead
-    uris: "{{ collection_prefix }}/v1/private/read"
-    upstream_url: "{{ content_service_url }}/collection/v4/private/read"
-    strip_uri: true
-    plugins:
-    - name: jwt
-    - name: cors
-    - "{{ statsd_pulgin }}"
-    - name: acl
-      config.whitelist:
-        - 'contentAccess'
-    - name: rate-limiting
-      config.policy: local
-      config.hour: "{{ medium_rate_limit_per_hour }}"
-      config.limit_by: credential
-    - name: request-size-limiting
-      config.allowed_payload_size: "{{ medium_request_size_limit }}"
-
   - name: collectionUpdate
     uris: "{{ collection_prefix }}/v1/update"
     upstream_url: "{{ content_service_url }}/collection/v4/update"
@@ -5569,24 +5515,6 @@ kong_apis:
       - name: request-size-limiting
         config.allowed_payload_size: "{{ medium_request_size_limit }}"
 
-  - name: questionPrivateRead
-    uris: "{{ question_prefix }}/v1/private/read"
-    upstream_url: "{{ assessment_service_url }}/question/v4/private/read"
-    strip_uri: true
-    plugins:
-      - name: jwt
-      - name: cors
-      - "{{ statsd_pulgin }}"
-      - name: acl
-        config.whitelist:
-          - 'contentAccess'
-      - name: rate-limiting
-        config.policy: local
-        config.hour: "{{ medium_rate_limit_per_hour }}"
-        config.limit_by: credential
-      - name: request-size-limiting
-        config.allowed_payload_size: "{{ medium_request_size_limit }}"
-
   - name: questionUpdate
     uris: "{{ question_prefix }}/v1/update"
     upstream_url: "{{ assessment_service_url }}/question/v4/update"
@@ -5700,24 +5628,6 @@ kong_apis:
         config.policy: local
         config.hour: "{{ medium_rate_limit_per_hour }}"
         config.limit_by: ip
-      - name: request-size-limiting
-        config.allowed_payload_size: "{{ medium_request_size_limit }}"
-
-  - name: questionSetPrivateRead
-    uris: "{{ questionset_prefix }}/v1/private/read"
-    upstream_url: "{{ assessment_service_url }}/questionset/v4/private/read"
-    strip_uri: true
-    plugins:
-      - name: jwt
-      - name: cors
-      - "{{ statsd_pulgin }}"
-      - name: acl
-        config.whitelist:
-          - 'contentAccess'
-      - name: rate-limiting
-        config.policy: local
-        config.hour: "{{ medium_rate_limit_per_hour }}"
-        config.limit_by: credential
       - name: request-size-limiting
         config.allowed_payload_size: "{{ medium_request_size_limit }}"
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-25735" title="SB-25735" target="_blank"><img alt="Epic" src="https://project-sunbird.atlassian.net/images/icons/issuetypes/epic.svg" />SB-25735</a>  Content Visibility - Allowing Creation, editing, and accessing(active/live content) of Private resource content on Diksha
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Reverts project-sunbird/sunbird-devops#2902