### PR TITLE
Fix: Onboard Search API for bot

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -7265,6 +7265,24 @@ kong_apis:
       config.limit_by: credential
     - name: request-size-limiting
       config.allowed_payload_size: "{{ small_request_size_limit }}"
+  
+  - name: searchBotByStartingMessage
+    uris: "{{ uci_admin_prefix }}/admin/v1/bot/getByParam"
+    upstream_url: "{{ uci_admin_service_url }}/admin/v1/bot/getByParam"
+    strip_uri: true
+    plugins:
+    - name: jwt
+    - name: cors
+    - "{{ statsd_pulgin }}"
+    - name: acl
+      config.whitelist:
+        - 'userAdmin'
+    - name: rate-limiting
+      config.policy: local
+      config.hour: "{{ medium_rate_limit_per_hour }}"
+      config.limit_by: credential
+    - name: request-size-limiting
+      config.allowed_payload_size: "{{ small_request_size_limit }}"
 
   - name: gqlUCI
     uris: "{{ uci_admin_prefix }}/uci-api/gql"


### PR DESCRIPTION
Add missing bot Search API for UCI.

#Note: This was missed during the first list of onboarding for UCI but we got to know when kong started splitting the API into two parts on the UI.
