### PR TITLE
Fix: Incorrect variable syntax for Blob URL in player

### DIFF
--- a/ansible/roles/stack-sunbird/templates/sunbird_player.env
+++ b/ansible/roles/stack-sunbird/templates/sunbird_player.env
@@ -194,4 +194,4 @@ sunbird_telemetry_service_local_url={{sunbird_telemetry_service_local_url | defa
 #Release-4.4.0
 sunbird_portal_video_max_size={{sunbird_portal_video_max_size | default(150)}}
 sunbird_default_file_size={{sunbird_default_file_size | default(150)}}
-sunbird_portal_uci_blob_url="{{ sunbird_portal_uci_blob_url | default('https://' + cloud_storage_url + '/uci') }}"
+sunbird_portal_uci_blob_url={{ sunbird_portal_uci_blob_url | default('https://' + cloud_storage_url + '/uci') }}


### PR DESCRIPTION
Fix `sunbird_portal_uci_blob_url` with incorrect syntax