### PR TITLE
UCI: Fix upstream route for updating CL

### DIFF
--- a/ansible/roles/kong-api/defaults/main.yml
+++ b/ansible/roles/kong-api/defaults/main.yml
@@ -7124,7 +7124,7 @@ kong_apis:
 
   - name: updateConversationLogicUCI
     uris: "{{ uci_admin_prefix }}/admin/v1/conversationLogic/update"
-    upstream_url: "{{ uci_admin_service_url }}/admin/v1/conversationLogic/delete"
+    upstream_url: "{{ uci_admin_service_url }}/admin/v1/conversationLogic/update"
     strip_uri: true
     plugins:
     - name: jwt


### PR DESCRIPTION
Bug Fix: the upstream route for updating CL mapped to delete.
