### PR TITLE
Fix: Add Netcore related env variables

### DIFF
--- a/ansible/roles/stack-sunbird/templates/outbound.env
+++ b/ansible/roles/stack-sunbird/templates/outbound.env
@@ -30,3 +30,8 @@ FUSIONAUTH_KEY={{fusionauth_service_admin_key}}
 
 #Ports
 OUTBOUND_INTERNAL_PORT=9090
+
+#Netcore
+NETCORE_WHATSAPP_AUTH_TOKEN={{uci_netcore_whatsapp_token}}
+NETCORE_WHATSAPP_SOURCE={{uci_netcore_whatsapp_source}}
+NETCORE_WHATSAPP_URI={{uci_netcore_whatsapp_uri | default('https://waapi.pepipost.com/api/v2/')}}

--- a/ansible/roles/stack-sunbird/templates/transformer.env
+++ b/ansible/roles/stack-sunbird/templates/transformer.env
@@ -45,3 +45,8 @@ CAMPAIGN_ADMIN_TOKEN={{uci_api_admin_token}}
 
 ASSESSMENT_GO_TO_START_CHAR={{uci_go_to_start_char | default("*") }}
 ASSESSMENT_ONE_LEVEL_UP_CHAR={{uci_one_level_up_char | default("#") }}
+
+#Netcore
+NETCORE_WHATSAPP_AUTH_TOKEN={{uci_netcore_whatsapp_token}}
+NETCORE_WHATSAPP_SOURCE={{uci_netcore_whatsapp_source}}
+NETCORE_WHATSAPP_URI={{uci_netcore_whatsapp_uri | default('https://waapi.pepipost.com/api/v2/')}}


### PR DESCRIPTION
Netcore env variables for different envs.
`uci_netcore_whatsapp_token `, `uci_netcore_whatsapp_source` have a private override (added to deployment tracker)