### PR TITLE
UCI Hotfix - Missed env variables.

### DIFF
--- a/ansible/roles/stack-sunbird/templates/inbound.env
+++ b/ansible/roles/stack-sunbird/templates/inbound.env
@@ -40,3 +40,5 @@ FUSIONAUTH_URL=http://fusionauth-service.{{namespace}}.svc.cluster.local:9011
 # API Key for Fusionauth. More details on how to generate this here -> https://fusionauth.io/docs/v1/tech/apis/authentication/#api-key-authentication
 # Note - You will need access to UI to generate this the first time.
 FUSIONAUTH_KEY={{fusionauth_service_admin_key}}
+
+CAMPAIGN_ADMIN_TOKEN={{uci_api_admin_token}}

--- a/ansible/roles/stack-sunbird/templates/orchestrator.env
+++ b/ansible/roles/stack-sunbird/templates/orchestrator.env
@@ -33,6 +33,8 @@ ORCHESTRATOR_INTERNAL_PORT=8686
 #FusionAuth
 FUSIONAUTH_URL=http://fusionauth-service.{{namespace}}.svc.cluster.local:9011
 
+CAMPAIGN_ADMIN_TOKEN={{uci_api_admin_token}}
+
 # API Key for Fusionauth. More details on how to generate this here -> https://fusionauth.io/docs/v1/tech/apis/authentication/#api-key-authentication
 # Note - You will need access to UI to generate this the first time.
 FUSIONAUTH_KEY={{fusionauth_service_admin_key}}


### PR DESCRIPTION
Hotfix: 2 missed env variables. Were wrongfully hardcoded in the code.