### PR TITLE
Issue #SB-28011 fix: portal_redirect_error_callback_domain var added

### DIFF
--- a/ansible/roles/stack-sunbird/templates/sunbird_player.env
+++ b/ansible/roles/stack-sunbird/templates/sunbird_player.env
@@ -196,3 +196,6 @@ sunbird_telemetry_service_local_url={{sunbird_telemetry_service_local_url | defa
 sunbird_portal_video_max_size={{sunbird_portal_video_max_size | default(150)}}
 sunbird_default_file_size={{sunbird_default_file_size | default(150)}}
 sunbird_portal_uci_blob_url={{ sunbird_portal_uci_blob_url | default('https://' + cloud_storage_url + '/uci') }}
+
+#Release-4.4.1
+portal_redirect_error_callback_domain={{portal_redirect_error_callback_domain | default("")}}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-28011" title="SB-28011" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />SB-28011</a>  Open Redirect Vulnerability is found at the web portal  ( Ref: CERTIn-26213521)
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
