### PR TITLE
Websocket handling for UCI Transport Socket

### DIFF
--- a/kubernetes/helm_charts/core/nginx-private-ingress/templates/configmap.yaml
+++ b/kubernetes/helm_charts/core/nginx-private-ingress/templates/configmap.yaml
@@ -221,6 +221,8 @@ data:
         location /uci-transport-socket/ {
           set $target http://uci-transport-socket-service.{{ .Values.namespace }}.svc.cluster.local:3000;
           rewrite ^/uci-transport-socket/(.*) /$1 break;
+          proxy_set_header Upgrade $http_upgrade;
+          proxy_set_header Connection "upgrade";
           proxy_pass $target;
         }
         location /ml-survey/ {


### PR DESCRIPTION
Fix: Nginx returning a 400 on `ws` connections. Added headers to handle the same.