### PR TITLE
Udpate Kafka Host in UCI API env (not there in prod)

### DIFF
--- a/ansible/roles/stack-sunbird/templates/uci_api.env
+++ b/ansible/roles/stack-sunbird/templates/uci_api.env
@@ -8,7 +8,7 @@ HASURA_GRAPHQL_ENABLED_LOG_TYPES=startup, http-log, webhook-log, websocket-log, 
 HASURA_GRAPHQL_ENABLE_CONSOLE=true
 
 #Kafka
-KAFKA_HOST={{kafka_broker_host}}
+KAFKA_HOST={{sunbird_processing_kafka_host}}
 KAFKA_PASS=""
 KAFKA_PORT=9092
 KAFKA_USER=""


### PR DESCRIPTION
`{{kafka_broker_host}}` not part of the prod env.