### PR TITLE
fix: ensure the line starts with the ip, fixes wrong matches

### DIFF
--- a/deploy/cassandra_backup.py
+++ b/deploy/cassandra_backup.py
@@ -147,7 +147,7 @@ if rc != 0:
 print("Schema backup completed. saved in {}/cassandra_backup/complete_db_schema.sql".format(tmpdir))
 
 # Backing up tokenring
-command = """ nodetool ring | grep """ + get_ip() + """ | awk '{print $NF ","}' | xargs | tee -a """ + tmpdir + """/cassandra_backup/tokenring.txt """ #.format(args.host, tmpdir)
+command = """ nodetool ring | grep ^""" + get_ip() + """ | awk '{print $NF ","}' | xargs | tee -a """ + tmpdir + """/cassandra_backup/tokenring.txt """ #.format(args.host, tmpdir)
 print(command)
 rc = system(command)
 if rc != 0:


### PR DESCRIPTION
`nodetool ring | grep 11.3.2.6`

The above grep expression matches patterns in the token ring numbers also, due to which the backup files are having additional token ring data which results in exeption as shown below
![Screenshot from 2022-05-10 15-34-38](https://user-images.githubusercontent.com/3581357/167604363-7f7ff878-6c5b-40e0-a2ca-8287471b6b50.png)

```
ERROR [main] 2022-05-10 09:49:52,711 CassandraDaemon.java:803 - Exception encountered during startup: The number of initial tokens (by initial_token) specified (257) is different from num_tokens value (256)
```

Instead we should search that the line starts with the IP as below which solves the tokenring issue during restore -

`nodetool ring | grep ^11.3.2.6`
