### PR TITLE
fix: move package names to ubuntu 20 and above, no support for ubuntu 18/16

### DIFF
--- a/ansible/bootstrap.yml
+++ b/ansible/bootstrap.yml
@@ -9,10 +9,7 @@
     - name: Installing other packages
       apt:
         state: present
-        name: "{{ item }}"
-      with_items:
-        - python-pkg-resources
-        - python-pip
+        name: ['python-pkg-resources', 'python3-pip']
   roles:
     - bootstrap_any
   tags:


### PR DESCRIPTION
fix: move package names to ubuntu 20 and above, no support for ubuntu 18/16