### PR TITLE
fix: use namespace variable to create namespaces

### DIFF
--- a/ansible/inventory/env/group_vars/all.yml
+++ b/ansible/inventory/env/group_vars/all.yml
@@ -531,7 +531,7 @@ cassandra_cluster_size: "{{ groups['cassandra'] | length }}"
 # This value is constant for sendgrid api authentication.
 # If you're using any other mail server provider, override this value in common.yaml.
 mail_server_username: "apikey"
-bootstrap_namespace: "{{ env }},flink-{{ env }},flink-kp-{{ env }}"
+bootstrap_namespace: "{{ namespace }},flink-{{ namespace }},flink-kp-{{ namespace }}"
 
 # Graylog vars shared across multiple roles
 graylog_open_to_public: false


### PR DESCRIPTION
fix: use namespace variable to create namespaces