### PR TITLE
fix: SB-29951 incorrect API rejection for similar looking urls

### DIFF
--- a/kubernetes/opa/learner/policies.rego
+++ b/kubernetes/opa/learner/policies.rego
@@ -15,6 +15,9 @@ urls_to_action_mapping := {
   "/v4/user/read": "getUserProfileV4",
   "/v5/user/read": "getUserProfileV5",
   "/v1/user/feed": "userFeed",
+  "/v1/user/feed/create": "userFeedCreate",
+  "/v1/user/feed/delete": "userFeedDelete",
+  "/v1/user/feed/update": "userFeedUpdate",
   "/v2/user/update": "updateUserV2",
   "/v3/user/update": "updateUserV3",
   "/v1/user/declarations": "updateUserDeclarations",
@@ -133,6 +136,22 @@ userFeed {
   super.public_role_check
   user_id := split(http_request.path, "/")[4]
   split(user_id, "?")[0] == super.userid
+}
+
+# Temporary fix as all feed url's begin with /v1/user/feed
+# Having only the userFeed (/v1/user/feed/:userid) block is causing issues for other similar routes like /v1/user/feed/create, /v1/user/feed/delete and /v1/user/feed/update
+# Adding the other url blocks below and making them a pass through to avoid rejecting the API incorrectly
+
+userFeedCreate {
+  true
+}
+
+userFeedDelete {
+  true
+}
+
+userFeedUpdate {
+  true
 }
 
 updateUserV2 {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29951" title="SB-29951" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-29951</a>  Create feed API is giving 403 error response
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
fix: SB-29951 incorrect API rejection for similar looking urls