### PR TITLE
fix: SB-29941 allow GET methods on public key retrieval API

### DIFF
--- a/kubernetes/opa/registry/policies.rego
+++ b/kubernetes/opa/registry/policies.rego
@@ -54,5 +54,5 @@ searchRCCertificate {
 
 # Retrieve public key API
 getRCPublicKey {
-  http_request.method == "POST"
+  http_request.method in ["POST", "GET"]
 }

--- a/kubernetes/opa/registry/policies_test.rego
+++ b/kubernetes/opa/registry/policies_test.rego
@@ -219,3 +219,20 @@ test_rc_certificate_search_public_key {
       }
     }
 }
+
+test_rc_certificate_get_public_key {
+    data.main.allow.allowed
+    with data.common.current_time as current_time
+    with data.common.iss as iss
+    with input as
+    {
+      "attributes": {
+        "request": {
+          "http": {
+            "path": "/api/v1/PublicKey/search/1-ab8bb63e-d4f2-11ec-9a7d-07cc64ac49c1",
+            "method": "GET"
+          }
+        }
+      }
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29941" title="SB-29941" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-29941</a>  Portal : Scanning the QR code for RC certificate gives an error stating " Scanned URL is Invalid" and gives an 403 error
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
fix: SB-29941 allow GET methods on public key retrieval API