### PR TITLE
fix: adding python interpreter var for newer ubuntu vms

### DIFF
--- a/kubernetes/ansible/api-manager.yml
+++ b/kubernetes/ansible/api-manager.yml
@@ -4,6 +4,7 @@
   become: yes
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
+    ANSIBLE_PYTHON_INTERPRETER: "/usr/bin/python2"
   vars_files:
     - "{{inventory_dir}}/secrets.yml"
   roles:


### PR DESCRIPTION
fix: adding python interpreter var for newer ubuntu vms