### PR TITLE
Ansible-postgres-patroni cluster

### DIFF
--- a/ansible/postgresql-patroni-cluster.yaml
+++ b/ansible/postgresql-patroni-cluster.yaml
@@ -1,0 +1,14 @@
+- hosts: etcd
+  become: yes
+  roles:
+    - ansible-etcd
+
+- hosts: postgresql
+  become: yes
+  roles:
+    - ansible-postgres_patroni
+
+- hosts: haproxy
+  become: yes
+  roles:
+    - ansible-haproxy

--- a/ansible/roles/ansible-etcd/README.md
+++ b/ansible/roles/ansible-etcd/README.md
@@ -1,0 +1,100 @@
+Role Name
+=========
+```
+postgresql-cluster-ansible
+```
+Requirements
+------------
+```
+1. comment or uncomment the properties in templates of the roles available as per the requirement.
+2. provide the variables where ever required.
+```
+Role Variables
+--------------
+```
+In hosts files:
+1. etcd_ip : <etcdip is to be provided for postgresql group and etcd group>
+2. postgresql_origin: <same as server ip>
+3. postgresql_1: <master postgres server Ip>
+4. postgresql_2: <postgres replica 1 server IP>
+5. postgresql_3: <postgres replica 2 server IP>
+
+
+etcd Role variables:
+etcd_name: "postgres-etcd"                                                        # cluster name
+etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
+etcd_initial_cluster_state: "postgres"                                            # initial cluster state
+etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
+etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
+etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
+etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
+etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
+
+Ansible-postgres_patroni role Variables:
+#patroni .yaml config
+Postgres_cluster_name: postgresql-prod      # Cluster name
+
+# users admin password
+admin_password: admin                       # Admin Password
+
+#Authentication
+# Replication
+replication_username: replicator            # Replication Username
+replication_password: password              # Replication password
+
+#SuperUser
+superuser_username: postgres                # Superuser username
+superuser_password: password                # Superuser Password
+```
+Architecture
+------------
+![Untitled Diagram (1)](https://user-images.githubusercontent.com/63706239/203470986-f8ec3d56-a6d2-4678-b594-dc20a29ec972.jpg)
+
+```
+Description:
+Ansible postgres cluter role is used to setup a postgres cluster with 1 Primary and 2 replicas where we are using the patroni as HA solution for postgres cluster.Patroni can be configured to handle tasks like replication, backups and restorations.We are also using HAProxy load Balancer to route the traffic and Etcd is a fault-tolerant, distributed key-value store that is used to store the state of the Postgres cluster. Via Patroni, all of the Postgres nodes make use of etcd to keep the Postgres cluster up and running.
+
+Users and applications can access the postgres server using Haproxy IP and Port defined in the haproxy configuration rules. 
+```
+
+Inventory hosts file as shown Below
+-----------------------------------
+```
+[etcd]
+192.168.245.129 etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+
+[postgresql]
+192.168.245.129 postgresql_origin=192.168.245.129 postgresql_1=192.168.245.129 postgresql_2=192.168.245.130 postgresql_3=192.168.245.131 etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+<postgres_server_2> postgresql_origin=<server_ip1> postgresql_1=<server_ip2> postgresql_2=<server_ip3> postgresql_3=<server_ip4> etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+<postgres_server_3> postgresql_origin=<server_ip1> postgresql_1=<server_ip2> postgresql_2=<server_ip3> postgresql_3=<server_ip4> etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+
+[haproxy]
+192.168.245.129 postgresql_1=192.168.245.129 postgresql_2=192.168.245.130 postgresql_3=192.168.245.131 ansible_ssh_user=ubuntu
+```
+
+License
+-------
+```
+BSD
+```
+Author Information
+------------------
+```
+Nikhil Varma
+
+Senior DevOps Engineer
+```
+
+postgres cluster setup using ansible
+-----------------------------------
+
+```
+# Command to run Ansibe-postgresql role
+
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass
+
+# Commands to run postgresql roles by using the tags and skipping the tags
+
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass --tags="<tag>"
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass --skip-tags="<tag>"
+```

--- a/ansible/roles/ansible-etcd/README.md
+++ b/ansible/roles/ansible-etcd/README.md
@@ -21,30 +21,30 @@ In hosts files:
 
 
 etcd Role variables:
-etcd_name: "postgres-etcd"                                                        # cluster name
-etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
-etcd_initial_cluster_state: "postgres"                                            # initial cluster state
-etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
-etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
-etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
-etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
-etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
+postgres_patroni_etcd_name: "postgres-etcd"                                                        # cluster name
+postgres_patroni_etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
+postgres_patroni_etcd_initial_cluster_state: "postgres"                                            # initial cluster state
+postgres_patroni_etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
+postgres_patroni_etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
+postgres_patroni_etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
+postgres_patroni_etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
+postgres_patroni_etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
 
 Ansible-postgres_patroni role Variables:
 #patroni .yaml config
-Postgres_cluster_name: postgresql-prod      # Cluster name
+postgres_cluster_name: postgresql-prod      # Cluster name
 
 # users admin password
-admin_password: admin                       # Admin Password
+postgres_patroni_admin_password: admin                       # Admin Password
 
 #Authentication
 # Replication
-replication_username: replicator            # Replication Username
-replication_password: password              # Replication password
+postgres_patroni_replication_username: replicator            # Replication Username
+postgres_patroni_replication_password: password              # Replication password
 
 #SuperUser
-superuser_username: postgres                # Superuser username
-superuser_password: password                # Superuser Password
+postgres_patroni_superuser_username: postgres                # Superuser username
+postgres_patroni_superuser_password: password                # Superuser Password
 ```
 Architecture
 ------------

--- a/ansible/roles/ansible-etcd/defaults/main.yml
+++ b/ansible/roles/ansible-etcd/defaults/main.yml
@@ -1,0 +1,14 @@
+---
+# defaults file for ansible-etcd
+
+
+# etcd cluster variables
+postgres_patroni_etcd_name: "postgres-etcd"
+postgres_patroni_etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"
+postgres_patroni_etcd_initial_cluster_state: "postgres"
+postgres_patroni_etcd_initial_cluster_token: "etcd-cluster-postgres"
+postgres_patroni_etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"
+postgres_patroni_etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"
+postgres_patroni_etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"
+postgres_patroni_etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"
+#etcd_data_dir:

--- a/ansible/roles/ansible-etcd/handlers/main.yml
+++ b/ansible/roles/ansible-etcd/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+# handlers file for ansible-etcd
+- name: Restart etcd systemd
+  systemd:
+    name: etcd.service
+    state: restarted
+    daemon_reload: yes
+
+- name: Restart etcd service
+  systemd:
+    name: etcd.service
+    state: restarted

--- a/ansible/roles/ansible-etcd/meta/main.yml
+++ b/ansible/roles/ansible-etcd/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: Nikhil Varma
+  description: Ansible-etcd for distributed key store for postgresql cluster
+#  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/ansible-etcd/tasks/main.yml
+++ b/ansible/roles/ansible-etcd/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# tasks file for ansible-etcd
+- name: Install etcd after updating apt
+  apt:
+    name:
+      - etcd
+    state: present
+    update_cache: yes
+  tags:
+    - etcd Install
+
+- name: Template configuration file to etcd
+  template:
+    src: etcd.j2
+    dest: '/etc/default/etcd'
+  notify:
+    - Restart etcd service
+  tags:
+    - Restart etcd

--- a/ansible/roles/ansible-etcd/templates/etcd.j2
+++ b/ansible/roles/ansible-etcd/templates/etcd.j2
@@ -1,0 +1,403 @@
+## etcd(1) daemon options
+## See "/usr/share/doc/etcd-server/op-guide/configuration.md.gz"
+
+### Member flags
+
+##### --name
+## Human-readable name for this member.
+## This value is referenced as this node's own entries listed in the
+## `--initial-cluster` flag (e.g., `default=http://localhost:2380`). This
+## needs to match the key used in the flag if using static bootstrapping. When
+## using discovery, each member must have a unique name. `Hostname` or
+## `machine-id` can be a good choice.
+## default: "default"
+#ETCD_NAME="postgres-etcd"
+
+##### --data-dir
+## Path to the data directory.
+## default: "${name}.etcd"
+# ETCD_DATA_DIR="/var/lib/etcd/default"
+
+##### --wal-dir
+## Path to the dedicated wal directory. If this flag is set, etcd will write
+## the WAL files to the walDir rather than the dataDir. This allows a
+## dedicated disk to be used, and helps avoid io competition between logging
+## and other IO operations.
+## default: ""
+# ETCD_WAL_DIR
+
+##### --snapshot-count
+## Number of committed transactions to trigger a snapshot to disk.
+## default: "100000"
+# ETCD_SNAPSHOT_COUNT="100000"
+
+##### --heartbeat-interval
+## Time (in milliseconds) of a heartbeat interval.
+## default: "100"
+# ETCD_HEARTBEAT_INTERVAL="100"
+
+##### --election-timeout
+## Time (in milliseconds) for an election to timeout. See
+## /usr/share/doc/etcd-server/tuning.md.gz for details.
+## default: "1000"
+# ETCD_ELECTION_TIMEOUT="1000"
+
+##### --listen-peer-urls
+## List of URLs to listen on for peer traffic. This flag tells the etcd to
+## accept incoming requests from its peers on the specified scheme://IP:port
+## combinations. Scheme can be either http or https.If 0.0.0.0 is specified as
+## the IP, etcd listens to the given port on all interfaces. If an IP address is
+## given as well as a port, etcd will listen on the given port and interface.
+## Multiple URLs may be used to specify a number of addresses and ports to listen
+## on. The etcd will respond to requests from any of the listed addresses and
+## ports.
+## default: "http://localhost:2380"
+## example: "http://10.0.0.1:2380"
+## invalid example: "http://example.com:2380" (domain name is invalid for binding)
+#ETCD_LISTEN_PEER_URLS="http://172.51.1.29:2380"
+
+##### --listen-client-urls
+## List of URLs to listen on for client traffic. This flag tells the etcd to
+## accept incoming requests from the clients on the specified scheme://IP:port
+## combinations. Scheme can be either http or https. If 0.0.0.0 is specified as
+## the IP, etcd listens to the given port on all interfaces. If an IP address is
+## given as well as a port, etcd will listen on the given port and interface.
+## Multiple URLs may be used to specify a number of addresses and ports to listen
+## on. The etcd will respond to requests from any of the listed addresses and
+## ports.
+## default: "http://localhost:2379"
+## example: "http://10.0.0.1:2379"
+## invalid example: "http://example.com:2379" (domain name is invalid for binding)
+#ETCD_LISTEN_CLIENT_URLS="http://172.51.1.29:2379,http://127.0.0.1:2379"
+
+##### --max-snapshots
+## Maximum number of snapshot files to retain (0 is unlimited)
+## The default for users on Windows is unlimited, and manual purging down to 5
+## (or some preference for safety) is recommended.
+## default: 5
+# ETCD_MAX_SNAPSHOTS="5"
+
+##### --max-wals
+## Maximum number of wal files to retain (0 is unlimited)
+## The default for users on Windows is unlimited, and manual purging down to 5
+## (or some preference for safety) is recommended.
+## default: 5
+# ETCD_MAX_WALS="5"
+
+##### --cors
+## Comma-separated white list of origins for CORS (cross-origin resource
+## sharing).
+## default: none
+# ETCD_CORS
+
+#### --quota-backend-bytes
+## Raise alarms when backend size exceeds the given quota (0 defaults to low
+## space quota).
+## default: 0
+# ETCD_QUOTA_BACKEND_BYTES="0"
+
+#### --backend-batch-limit
+## BackendBatchLimit is the maximum operations before commit the backend
+## transaction.
+## default: 0
+# ETCD_BACKEND_BATCH_LIMIT="0"
+
+#### --backend-batch-interval
+## BackendBatchInterval is the maximum time before commit the backend
+## transaction.
+## default: 0
+# ETCD_BACKEND_BATCH_INTERVAL="0"
+
+#### --max-txn-ops
+## Maximum number of operations permitted in a transaction.
+## default: 128
+# ETCD_MAX_TXN_OPS="128"
+
+#### --max-request-bytes
+## Maximum client request size in bytes the server will accept.
+## default: 1572864
+# ETCD_MAX_REQUEST_BYTES="1572864"
+
+#### --grpc-keepalive-min-time
+## Minimum duration interval that a client should wait before pinging server.
+## default: 5s
+# ETCD_GRPC_KEEPALIVE_MIN_TIME="5"
+
+#### --grpc-keepalive-interval
+## Frequency duration of server-to-client ping to check if a connection is
+## alive (0 to disable).
+## default: 2h
+# ETCD_GRPC_KEEPALIVE_INTERVAL="2h"
+
+#### --grpc-keepalive-timeout
+## Additional duration of wait before closing a non-responsive connection
+## (0 to disable).
+## default: 20s
+# ETCD_GRPC_KEEPALIVE_TIMEOUT="20s"
+
+
+### Clustering flags
+
+# `--initial` prefix flags are used in bootstrapping (static bootstrap,
+# discovery-service bootstrap or runtime reconfiguration) a new member, and
+# ignored when restarting an existing member.
+
+# `--discovery` prefix flags need to be set when using discovery service.
+
+##### --initial-advertise-peer-urls
+
+## List of this member's peer URLs to advertise to the rest of the cluster.
+## These addresses are used for communicating etcd data around the cluster. At
+## least one must be routable to all cluster members. These URLs can contain
+## domain names.
+## default: "http://localhost:2380"
+## example: "http://example.com:2380, http://10.0.0.1:2380"
+#ETCD_INITIAL_ADVERTISE_PEER_URLS="http://172.51.1.29:2380"
+
+##### --initial-cluster
+## Initial cluster configuration for bootstrapping.
+## The key is the value of the `--name` flag for each node provided. The
+## default uses `default` for the key because this is the default for the
+## `--name` flag.
+## default: "default=http://localhost:2380"
+#ETCD_INITIAL_CLUSTER="postgres-etcd=http://172.51.1.29:2380"
+
+##### --initial-cluster-state
+## Initial cluster state ("new" or "existing"). Set to `new` for all members
+## present during initial static or DNS bootstrapping. If this option is set to
+## `existing`, etcd will attempt to join the existing cluster. If the wrong value
+## is set, etcd will attempt to start but fail safely.
+## default: "new"
+# ETCD_INITIAL_CLUSTER_STATE="new"
+
+##### --initial-cluster-token
+## Initial cluster token for the etcd cluster during bootstrap.
+## default: "etcd-cluster"
+#ETCD_INITIAL_CLUSTER_TOKEN="etcd-cluster"
+
+##### --advertise-client-urls
+## List of this member's client URLs to advertise to the rest of the cluster.
+## These URLs can contain domain names.
+## Be careful if advertising URLs such as http://localhost:2379 from a cluster
+## member and are using the proxy feature of etcd. This will cause loops, because
+## the proxy will be forwarding requests to itself until its resources (memory,
+## file descriptors) are eventually depleted.
+## default: "http://localhost:2379"
+## example: "http://example.com:2379, http://10.0.0.1:2379"
+#ETCD_ADVERTISE_CLIENT_URLS="http://172.51.1.29:2379"
+
+##### --discovery
+## Discovery URL used to bootstrap the cluster.
+## default: none
+# ETCD_DISCOVERY
+
+##### --discovery-srv
+## DNS srv domain used to bootstrap the cluster.
+## default: none
+# ETCD_DISCOVERY_SRV
+
+##### --discovery-fallback
+## Expected behavior ("exit" or "proxy") when discovery services fails. "proxy"
+## supports v2 API only.
+## default: "proxy"
+# ETCD_DISCOVERY_FALLBACK="proxy"
+
+##### --discovery-proxy
+## HTTP proxy to use for traffic to discovery service.
+## default: none
+# ETCD_DISCOVERY_PROXY
+
+##### --strict-reconfig-check
+## Reject reconfiguration requests that would cause quorum loss.
+## default: false
+# ETCD_STRICT_RECONFIG_CHECK
+
+##### --auto-compaction-retention
+## Auto compaction retention for mvcc key value store in hour. 0 means disable
+## auto compaction.
+## default: 0
+# ETCD_AUTO_COMPACTION_RETENTION="0"
+
+##### --enable-v2
+## Accept etcd V2 client requests
+## default: true
+# ETCD_ENABLE_V2="true"
+
+
+### Proxy flags
+
+# `--proxy` prefix flags configures etcd to run in proxy mode. "proxy" supports
+# v2 API only.
+
+##### --proxy
+## Proxy mode setting ("off", "readonly" or "on").
+## default: "off"
+# ETCD_PROXY="off"
+
+##### --proxy-failure-wait
+## Time (in milliseconds) an endpoint will be held in a failed state before
+## being reconsidered for proxied requests.
+## default: 5000
+# ETCD_PROXY_FAILURE_WAIT="5000"
+
+##### --proxy-refresh-interval
+## Time (in milliseconds) of the endpoints refresh interval.
+## default: 30000
+# ETCD_PROXY_REFRESH_INTERVAL="30000"
+
+##### --proxy-dial-timeout
+## Time (in milliseconds) for a dial to timeout or 0 to disable the timeout
+## default: 1000
+# ETCD_PROXY_DIAL_TIMEOUT="1000"
+
+##### --proxy-write-timeout
+## Time (in milliseconds) for a write to timeout or 0 to disable the timeout.
+## default: 5000
+# ETCD_PROXY_WRITE_TIMEOUT="5000"
+
+##### --proxy-read-timeout
+## Time (in milliseconds) for a read to timeout or 0 to disable the timeout.
+## Don't change this value if using watches because use long polling requests.
+## default: 0
+# ETCD_PROXY_READ_TIMEOUT="0"
+
+
+### Security flags
+
+# The security flags help to build a secure etcd cluster.
+
+##### --ca-file (**DEPRECATED**)
+## Path to the client server TLS CA file. `--ca-file ca.crt` could be replaced
+## by `--trusted-ca-file ca.crt --client-cert-auth` and etcd will perform the
+## same.
+## default: none
+# ETCD_CA_FILE
+
+##### --cert-file
+## Path to the client server TLS cert file.
+## default: none
+# ETCD_CERT_FILE
+
+##### --key-file
+## Path to the client server TLS key file.
+## default: none
+# ETCD_KEY_FILE
+
+##### --client-cert-auth
+## Enable client cert authentication.
+## CN authentication is not supported by gRPC-gateway.
+## default: false
+# ETCD_CLIENT_CERT_AUTH
+
+#### --client-crl-file
+## Path to the client certificate revocation list file.
+## default: ""
+# ETCD_CLIENT_CRL_FILE
+
+##### --trusted-ca-file
+## Path to the client server TLS trusted CA key file.
+## default: none
+# ETCD_TRUSTED_CA_FILE
+
+##### --auto-tls
+## Client TLS using generated certificates
+## default: false
+# ETCD_AUTO_TLS
+
+##### --peer-ca-file (**DEPRECATED**)
+## Path to the peer server TLS CA file. `--peer-ca-file ca.crt` could be
+## replaced by `--peer-trusted-ca-file ca.crt --peer-client-cert-auth` and etcd
+## will perform the same.
+## default: none
+# ETCD_PEER_CA_FILE
+
+##### --peer-cert-file
+## Path to the peer server TLS cert file.
+## default: none
+# ETCD_PEER_CERT_FILE
+
+##### --peer-key-file
+## Path to the peer server TLS key file.
+## default: none
+# ETCD_PEER_KEY_FILE
+
+##### --peer-client-cert-auth
+## Enable peer client cert authentication.
+## default: false
+# ETCD_PEER_CLIENT_CERT_AUTH
+
+#### --peer-crl-file
+## Path to the peer certificate revocation list file.
+## default: ""
+# ETCD_PEER_CRL_FILE
+
+##### --peer-trusted-ca-file
+## Path to the peer server TLS trusted CA file.
+## default: none
+# ETCD_PEER_TRUSTED_CA_FILE
+
+##### --peer-auto-tls
+## Peer TLS using generated certificates
+## default: false
+# ETCD_PEER_AUTO_TLS
+
+#### --peer-cert-allowed-cn
+## Allowed CommonName for inter peer authentication.
+## default: none
+# ETCD_PEER_CERT_ALLOWED_CN
+
+#### --cipher-suites
+## Comma-separated list of supported TLS cipher suites between server/client and
+## peers.
+## default: ""
+# ETCD_CIPHER_SUITES
+
+#### --experimental-peer-skip-client-san-verification
+## Skip verification of SAN field in client certificate for peer connections.
+## default: false
+#+ ETCD_EXPERIMENTAL_PEER_SKIP_CLIENT_SAN_VERIFICATION
+
+
+### Logging flags
+
+#### --log-outputs
+## Specify 'stdout' or 'stderr' to skip journald logging even when running
+## under systemd, or list of comma separated output targets.
+## default: default
+# ETCD_LOG_OUTPUTS
+
+##### --debug
+## Drop the default log level to DEBUG for all subpackages.
+## default: false (INFO for all packages)
+# ETCD_DEBUG
+
+##### --log-package-levels
+## Set individual etcd subpackages to specific log levels. An example being
+## `etcdserver=WARNING,security=DEBUG`
+## default: none (INFO for all packages)
+# ETCD_LOG_PACKAGE_LEVELS
+
+
+### Unsafe flags
+
+# Please be CAUTIOUS when using unsafe flags because it will break the guarantees given by the consensus protocol.
+# For example, it may panic if other members in the cluster are still alive.
+# Follow the instructions when using these flags.
+
+##### --force-new-cluster
+## Force to create a new one-member cluster. It commits configuration changes
+## forcing to remove all existing members in the cluster and add itself. It needs
+## to be set to restore a backup.
+## default: false
+# ETCD_FORCE_NEW_CLUSTER
+#
+#
+ETCD_INITIAL_CLUSTER="{{ postgres_patroni_etcd_initial_cluster }}"
+ETCD_INITIAL_CLUSTER_STATE="{{ postgres_patroni_etcd_initial_cluster_state }}"
+ETCD_INITIAL_CLUSTER_TOKEN="{{ postgres_patroni_etcd_initial_cluster_token }}"
+ETCD_INITIAL_ADVERTISE_PEER_URLS="{{ postgres_patroni_etcd_initial_advertise_peer_urls }}"
+#ETCD_DATA_DIR="/var/etcd"
+ETCD_LISTEN_PEER_URLS="{{ postgres_patroni_etcd_listen_peer_urls }}"
+ETCD_LISTEN_CLIENT_URLS="{{ postgres_patroni_etcd_listen_client_urls }}"
+ETCD_ADVERTISE_CLIENT_URLS="{{ postgres_patroni_etcd_advertise_client_urls }}"
+ETCD_NAME="{{ postgres_patroni_etcd_name }}"

--- a/ansible/roles/ansible-etcd/vars/main.yml
+++ b/ansible/roles/ansible-etcd/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ansible-etcd

--- a/ansible/roles/ansible-haproxy/README.md
+++ b/ansible/roles/ansible-haproxy/README.md
@@ -1,0 +1,100 @@
+Role Name
+=========
+```
+postgresql-cluster-ansible
+```
+Requirements
+------------
+```
+1. comment or uncomment the properties in templates of the roles available as per the requirement.
+2. provide the variables where ever required.
+```
+Role Variables
+--------------
+```
+In hosts files:
+1. etcd_ip : <etcdip is to be provided for postgresql group and etcd group>
+2. postgresql_origin: <same as server ip>
+3. postgresql_1: <master postgres server Ip>
+4. postgresql_2: <postgres replica 1 server IP>
+5. postgresql_3: <postgres replica 2 server IP>
+
+
+etcd Role variables:
+etcd_name: "postgres-etcd"                                                        # cluster name
+etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
+etcd_initial_cluster_state: "postgres"                                            # initial cluster state
+etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
+etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
+etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
+etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
+etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
+
+Ansible-postgres_patroni role Variables:
+#patroni .yaml config
+Postgres_cluster_name: postgresql-prod      # Cluster name
+
+# users admin password
+admin_password: admin                       # Admin Password
+
+#Authentication
+# Replication
+replication_username: replicator            # Replication Username
+replication_password: password              # Replication password
+
+#SuperUser
+superuser_username: postgres                # Superuser username
+superuser_password: password                # Superuser Password
+```
+Architecture
+------------
+![Untitled Diagram (1)](https://user-images.githubusercontent.com/63706239/203470986-f8ec3d56-a6d2-4678-b594-dc20a29ec972.jpg)
+
+```
+Description:
+Ansible postgres cluter role is used to setup a postgres cluster with 1 Primary and 2 replicas where we are using the patroni as HA solution for postgres cluster.Patroni can be configured to handle tasks like replication, backups and restorations.We are also using HAProxy load Balancer to route the traffic and Etcd is a fault-tolerant, distributed key-value store that is used to store the state of the Postgres cluster. Via Patroni, all of the Postgres nodes make use of etcd to keep the Postgres cluster up and running.
+
+Users and applications can access the postgres server using Haproxy IP and Port defined in the haproxy configuration rules. 
+```
+
+Inventory hosts file as shown Below
+-----------------------------------
+```
+[etcd]
+192.168.245.129 etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+
+[postgresql]
+192.168.245.129 postgresql_origin=192.168.245.129 postgresql_1=192.168.245.129 postgresql_2=192.168.245.130 postgresql_3=192.168.245.131 etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+<postgres_server_2> postgresql_origin=<server_ip1> postgresql_1=<server_ip2> postgresql_2=<server_ip3> postgresql_3=<server_ip4> etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+<postgres_server_3> postgresql_origin=<server_ip1> postgresql_1=<server_ip2> postgresql_2=<server_ip3> postgresql_3=<server_ip4> etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+
+[haproxy]
+192.168.245.129 postgresql_1=192.168.245.129 postgresql_2=192.168.245.130 postgresql_3=192.168.245.131 ansible_ssh_user=ubuntu
+```
+
+License
+-------
+```
+BSD
+```
+Author Information
+------------------
+```
+Nikhil Varma
+
+Senior DevOps Engineer
+```
+
+postgres cluster setup using ansible
+-----------------------------------
+
+```
+# Command to run Ansibe-postgresql role
+
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass
+
+# Commands to run postgresql roles by using the tags and skipping the tags
+
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass --tags="<tag>"
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass --skip-tags="<tag>"
+```

--- a/ansible/roles/ansible-haproxy/README.md
+++ b/ansible/roles/ansible-haproxy/README.md
@@ -21,30 +21,30 @@ In hosts files:
 
 
 etcd Role variables:
-etcd_name: "postgres-etcd"                                                        # cluster name
-etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
-etcd_initial_cluster_state: "postgres"                                            # initial cluster state
-etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
-etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
-etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
-etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
-etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
+postgres_patroni_etcd_name: "postgres-etcd"                                                        # cluster name
+postgres_patroni_etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
+postgres_patroni_etcd_initial_cluster_state: "postgres"                                            # initial cluster state
+postgres_patroni_etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
+postgres_patroni_etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
+postgres_patroni_etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
+postgres_patroni_etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
+postgres_patroni_etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
 
 Ansible-postgres_patroni role Variables:
 #patroni .yaml config
-Postgres_cluster_name: postgresql-prod      # Cluster name
+postgres_cluster_name: postgresql-prod      # Cluster name
 
 # users admin password
-admin_password: admin                       # Admin Password
+postgres_patroni_admin_password: admin                       # Admin Password
 
 #Authentication
 # Replication
-replication_username: replicator            # Replication Username
-replication_password: password              # Replication password
+postgres_patroni_replication_username: replicator            # Replication Username
+postgres_patroni_replication_password: password              # Replication password
 
 #SuperUser
-superuser_username: postgres                # Superuser username
-superuser_password: password                # Superuser Password
+postgres_patroni_superuser_username: postgres                # Superuser username
+postgres_patroni_superuser_password: password                # Superuser Password
 ```
 Architecture
 ------------

--- a/ansible/roles/ansible-haproxy/defaults/main.yml
+++ b/ansible/roles/ansible-haproxy/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for ansible-haproxy

--- a/ansible/roles/ansible-haproxy/handlers/main.yml
+++ b/ansible/roles/ansible-haproxy/handlers/main.yml
@@ -1,0 +1,12 @@
+---
+# handlers file for ansible-haproxy
+- name: Restart haproxy systemd
+  systemd:
+    name: haproxy.service
+    state: restarted
+    daemon_reload: yes
+
+- name: Restart haproxy service
+  systemd:
+    name: haproxy.service
+    state: restarted

--- a/ansible/roles/ansible-haproxy/meta/main.yml
+++ b/ansible/roles/ansible-haproxy/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: Nikhil Varma
+  description: Ansible HAProxy for postgresql cluster
+  #company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/ansible-haproxy/tasks/main.yml
+++ b/ansible/roles/ansible-haproxy/tasks/main.yml
@@ -1,0 +1,19 @@
+---
+# tasks file for ansible-haproxy
+- name: Install HaProxy after updating apt
+  apt:
+    name:
+      - haproxy
+    state: present
+    update_cache: yes
+  tags:
+    - HaProxy Install
+
+- name: Template configuration file to haproxy.cfg
+  template:
+    src: haproxy.cfg.j2
+    dest: '/etc/haproxy/haproxy.cfg'
+  notify:
+    - Restart haproxy service
+  tags:
+    - Restart haproxy

--- a/ansible/roles/ansible-haproxy/templates/haproxy.cfg.j2
+++ b/ansible/roles/ansible-haproxy/templates/haproxy.cfg.j2
@@ -1,0 +1,26 @@
+global
+    maxconn 100
+
+defaults
+    log global
+    mode tcp
+    retries 2
+    timeout client 30m
+    timeout connect 4s
+    timeout server 30m
+    timeout check 5s
+
+listen stats
+    mode http
+    bind *:7000
+    stats enable
+    stats uri /
+
+listen postgres
+    bind *:5000
+    option httpchk
+    http-check expect status 200
+    default-server inter 3s fall 3 rise 2 on-marked-down shutdown-sessions
+    server postgresql_{{ postgresql_1 }}_5432 {{ postgresql_1 }}:5432 maxconn 100 check port 8008
+    server postgresql_{{ postgresql_2 }}_5432 {{ postgresql_2 }}:5432 maxconn 100 check port 8008
+    server postgresql_{{ postgresql_3 }}_5432 {{ postgresql_3 }}:5432 maxconn 100 check port 8008

--- a/ansible/roles/ansible-haproxy/vars/main.yml
+++ b/ansible/roles/ansible-haproxy/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ansible-haproxy

--- a/ansible/roles/ansible-postgres_patroni/README.md
+++ b/ansible/roles/ansible-postgres_patroni/README.md
@@ -1,0 +1,100 @@
+Role Name
+=========
+```
+postgresql-cluster-ansible
+```
+Requirements
+------------
+```
+1. comment or uncomment the properties in templates of the roles available as per the requirement.
+2. provide the variables where ever required.
+```
+Role Variables
+--------------
+```
+In hosts files:
+1. etcd_ip : <etcdip is to be provided for postgresql group and etcd group>
+2. postgresql_origin: <same as server ip>
+3. postgresql_1: <master postgres server Ip>
+4. postgresql_2: <postgres replica 1 server IP>
+5. postgresql_3: <postgres replica 2 server IP>
+
+
+etcd Role variables:
+etcd_name: "postgres-etcd"                                                        # cluster name
+etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
+etcd_initial_cluster_state: "postgres"                                            # initial cluster state
+etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
+etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
+etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
+etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
+etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
+
+Ansible-postgres_patroni role Variables:
+#patroni .yaml config
+Postgres_cluster_name: postgresql-prod      # Cluster name
+
+# users admin password
+admin_password: admin                       # Admin Password
+
+#Authentication
+# Replication
+replication_username: replicator            # Replication Username
+replication_password: password              # Replication password
+
+#SuperUser
+superuser_username: postgres                # Superuser username
+superuser_password: password                # Superuser Password
+```
+Architecture
+------------
+![Untitled Diagram (1)](https://user-images.githubusercontent.com/63706239/203470986-f8ec3d56-a6d2-4678-b594-dc20a29ec972.jpg)
+
+```
+Description:
+Ansible postgres cluter role is used to setup a postgres cluster with 1 Primary and 2 replicas where we are using the patroni as HA solution for postgres cluster.Patroni can be configured to handle tasks like replication, backups and restorations.We are also using HAProxy load Balancer to route the traffic and Etcd is a fault-tolerant, distributed key-value store that is used to store the state of the Postgres cluster. Via Patroni, all of the Postgres nodes make use of etcd to keep the Postgres cluster up and running.
+
+Users and applications can access the postgres server using Haproxy IP and Port defined in the haproxy configuration rules. 
+```
+
+Inventory hosts file as shown Below
+-----------------------------------
+```
+[etcd]
+192.168.245.129 etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+
+[postgresql]
+192.168.245.129 postgresql_origin=192.168.245.129 postgresql_1=192.168.245.129 postgresql_2=192.168.245.130 postgresql_3=192.168.245.131 etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+<postgres_server_2> postgresql_origin=<server_ip1> postgresql_1=<server_ip2> postgresql_2=<server_ip3> postgresql_3=<server_ip4> etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+<postgres_server_3> postgresql_origin=<server_ip1> postgresql_1=<server_ip2> postgresql_2=<server_ip3> postgresql_3=<server_ip4> etcd_ip=192.168.245.129 ansible_ssh_user=ubuntu
+
+[haproxy]
+192.168.245.129 postgresql_1=192.168.245.129 postgresql_2=192.168.245.130 postgresql_3=192.168.245.131 ansible_ssh_user=ubuntu
+```
+
+License
+-------
+```
+BSD
+```
+Author Information
+------------------
+```
+Nikhil Varma
+
+Senior DevOps Engineer
+```
+
+postgres cluster setup using ansible
+-----------------------------------
+
+```
+# Command to run Ansibe-postgresql role
+
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass
+
+# Commands to run postgresql roles by using the tags and skipping the tags
+
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass --tags="<tag>"
+$ ansible-playbook -i inventory/hosts main.yaml -K --ask-pass --skip-tags="<tag>"
+```

--- a/ansible/roles/ansible-postgres_patroni/README.md
+++ b/ansible/roles/ansible-postgres_patroni/README.md
@@ -21,30 +21,30 @@ In hosts files:
 
 
 etcd Role variables:
-etcd_name: "postgres-etcd"                                                        # cluster name
-etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
-etcd_initial_cluster_state: "postgres"                                            # initial cluster state
-etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
-etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
-etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
-etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
-etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
+postgres_patroni_etcd_name: "postgres-etcd"                                                        # cluster name
+postgres_patroni_etcd_initial_cluster: "{{ etcd_name }}=http://{{ etcd_ip }}:2380"                 # initial cluster
+postgres_patroni_etcd_initial_cluster_state: "postgres"                                            # initial cluster state
+postgres_patroni_etcd_initial_cluster_token: "etcd-cluster-postgres"                               # initial cluster token
+postgres_patroni_etcd_initial_advertise_peer_urls: "http://{{ etcd_ip }}:2380"                     # initial advertise peer urls
+postgres_patroni_etcd_listen_peer_urls: "http://{{ etcd_ip }}:2380"                                # listen peer urls
+postgres_patroni_etcd_listen_client_urls: "http://{{ etcd_ip }}:2379,http://127.0.0.1:2379"        # listen client urls
+postgres_patroni_etcd_advertise_client_urls: "http://{{ etcd_ip }}:2379"                           # advertise client urls
 
 Ansible-postgres_patroni role Variables:
 #patroni .yaml config
 Postgres_cluster_name: postgresql-prod      # Cluster name
 
 # users admin password
-admin_password: admin                       # Admin Password
+postgres_patroni_admin_password: admin                       # Admin Password
 
 #Authentication
 # Replication
-replication_username: replicator            # Replication Username
-replication_password: password              # Replication password
+postgres_patroni_replication_username: replicator            # Replication Username
+postgres_patroni_replication_password: password              # Replication password
 
 #SuperUser
-superuser_username: postgres                # Superuser username
-superuser_password: password                # Superuser Password
+postgres_patroni_superuser_username: postgres                # Superuser username
+postgres_patroni_superuser_password: password                # Superuser Password
 ```
 Architecture
 ------------

--- a/ansible/roles/ansible-postgres_patroni/defaults/main.yml
+++ b/ansible/roles/ansible-postgres_patroni/defaults/main.yml
@@ -1,0 +1,16 @@
+---
+# defaults file for ansible-postgres_patroni
+#patroni .yaml config
+postgres_cluster_name: postgresql-prod
+
+# users admin password
+postgres_patroni_admin_password: admin
+
+#Authentication
+# Replication
+postgres_patroni_replication_username: replicator
+postgres_patroni_replication_password: password
+
+#SuperUser
+postgres_patroni_superuser_username: postgres
+postgres_patroni_superuser_password: password

--- a/ansible/roles/ansible-postgres_patroni/handlers/main.yml
+++ b/ansible/roles/ansible-postgres_patroni/handlers/main.yml
@@ -1,0 +1,18 @@
+---
+# handlers file for ansible-postgres_patroni
+- name: Restart patroni systemd
+  systemd:
+    name: patroni.service
+    state: restarted
+    daemon_reload: yes
+
+- name: Restart patroni service
+  systemd:
+    name: patroni.service
+    state: restarted
+
+- name: Start the postgresql service
+  systemd:
+    name: postgresql.service
+    state: started
+    enabled: yes

--- a/ansible/roles/ansible-postgres_patroni/meta/main.yml
+++ b/ansible/roles/ansible-postgres_patroni/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: Nikhil Varma
+  description: Ansible role for setting up postgresql cluster
+  #company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/ansible/roles/ansible-postgres_patroni/tasks/main.yml
+++ b/ansible/roles/ansible-postgres_patroni/tasks/main.yml
@@ -1,0 +1,105 @@
+---
+# tasks file for ansible-postgres_patroni
+
+- name: Install postgresql after updating apt
+  apt:
+    name:
+      - postgresql
+      - postgresql-contrib
+    state: present
+    update_cache: yes
+  tags:
+    - postgresql Install
+
+- name: Stop the postgresql service
+  systemd:
+    name: postgresql.service
+    state: stopped
+    enabled: yes
+  tags:
+    - postgresql_service
+
+- name: creating softlink for postgres
+  ansible.builtin.shell:
+    cmd: ln -s /usr/lib/postgresql/15/bin/* /usr/sbin/
+  tags:
+    - softlink
+
+- name: Install and update python and pip
+  apt:
+    name:
+      - python3-pip
+      - python3-dev
+      - libpq-dev
+    state: present
+  tags:
+    - pip_python
+
+- name: Upgrade pip to latest vesion
+  pip:
+    name: pip
+    extra_args: --upgrade
+    state: latest
+  tags:
+    - upgrade_pip
+
+- name: Install patroni and dependencies
+  pip:
+    name: 
+      - patroni
+      - python-etcd
+      - psycopg2
+    state: present
+  tags:
+    - install patroni
+
+- name: Creates data directory for patroni
+  file:
+    path: /data
+    state: directory
+    mode: 0700
+    owner: postgres
+    group: postgres
+  tags:
+    - create_data_dir
+
+- name: Creates data directory for patroni
+  file:
+    path: /data/patroni
+    state: directory
+    mode: 0700
+    owner: postgres
+    group: postgres
+  tags:
+    - create_patroni_dir
+
+
+- name: Template patroni systemd service file to /etc/systemd/system/patroni.service
+  template:
+    src: patroni.service.j2
+    dest: /etc/systemd/system/patroni.service
+  tags:
+    - patroni_service
+
+- name: Restart patroni systemd
+  systemd:
+    name: patroni.service
+    state: restarted
+    daemon_reload: yes
+
+- name: Template configuration file to patroni.yaml
+  template:
+    src: patroni.yaml.j2
+    dest: '/etc/patroni.yaml'
+  tags:
+    - patroni_config
+
+- name: Restart patroni service
+  systemd:
+    name: patroni.service
+    state: restarted
+
+- name: Restart postgres service
+  systemd:
+    name: postgresql.service
+    state: restarted

--- a/ansible/roles/ansible-postgres_patroni/templates/patroni.service.j2
+++ b/ansible/roles/ansible-postgres_patroni/templates/patroni.service.j2
@@ -1,0 +1,17 @@
+[Unit]
+Description=Runners to orchestrate a high-availability PostgreSQL
+After=syslog.target network.target
+
+[Service]
+Type=simple
+
+User=postgres
+Group=postgres
+
+ExecStart=/usr/local/bin/patroni /etc/patroni.yaml
+KillMode=process
+TimeoutSec=30
+Restart=no
+
+[Install]
+WantedBy=multi-user.targ

--- a/ansible/roles/ansible-postgres_patroni/templates/patroni.yaml.j2
+++ b/ansible/roles/ansible-postgres_patroni/templates/patroni.yaml.j2
@@ -1,0 +1,58 @@
+scope: postgres
+namespace: /db/
+name: {{ postgres_cluster_name }}
+
+restapi:
+    listen: {{ postgresql_origin }}:8008
+    connect_address: {{ postgresql_origin }}:8008
+
+etcd:
+    host: {{ etcd_ip }}:2379
+
+bootstrap:
+    dcs:
+        ttl: 30
+        loop_wait: 10
+        retry_timeout: 10
+        maximum_lag_on_failover: 1048576
+        postgresql:
+            use_pg_rewind: true
+
+    initdb:
+    - encoding: UTF8
+    - data-checksums
+
+    pg_hba:
+    - host replication replicator 127.0.0.1/32 md5
+    - host replication replicator {{ postgresql_1 }}/0 md5
+    - host replication replicator {{ postgresql_2 }}/0 md5
+    - host replication replicator {{ postgresql_3 }}/0 md5
+    - host all all 0.0.0.0/0 md5
+
+    users:
+        admin:
+            password: {{ postgres_patroni_admin_password }}
+            options:
+                - createrole
+                - createdb
+
+postgresql:
+    listen: {{ postgresql_origin }}:5432
+    connect_address: {{ postgresql_origin }}:5432
+    data_dir: /data/patroni
+    pgpass: /tmp/pgpass
+    authentication:
+        replication:
+            username: {{ postgres_patroni_replication_username }}
+            password: {{ postgres_patroni_replication_password }}
+        superuser:
+            username: {{ postgres_patroni_superuser_username }}
+            password: {{ postgres_patroni_superuser_password }}
+    parameters:
+        unix_socket_directories: '.'
+
+tags:
+    nofailover: false
+    noloadbalance: false
+    clonefrom: false
+    nosync: false

--- a/ansible/roles/ansible-postgres_patroni/vars/main.yml
+++ b/ansible/roles/ansible-postgres_patroni/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ansible-postgres_patroni


### PR DESCRIPTION
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

Architecture:
![image](https://user-images.githubusercontent.com/63706239/209305837-1b48d7a6-cd86-4194-8d2c-c3991b0d44f7.png)


Ansible postgres cluter role is used to setup a postgres cluster with 1 Primary and 2 replicas where we are using the patroni as HA solution for postgres cluster.Patroni can be configured to handle tasks like replication, backups and restorations.We are also using HAProxy load Balancer to route the traffic and Etcd is a fault-tolerant, distributed key-value store that is used to store the state of the Postgres cluster. Via Patroni, all of the Postgres nodes make use of etcd to keep the Postgres cluster up and running.
Users and applications can access the postgres server using Haproxy IP and Port defined in the haproxy configuration rules.

postgres cluster setup using ansible:
# Command to run Ansibe-postgresql role
$ ansible-playbook -i inventory/hosts ansible/postgresql-patroni-cluster.yaml -K --ask-pass
# Commands to run postgresql roles by using the tags and skipping the tags
$ ansible-playbook -i inventory/hosts ansible/postgresql-patroni-cluster.yaml -K --ask-pass --tags="<tag>"
$ ansible-playbook -i inventory/hosts ansible/postgresql-patroni-cluster.yaml -K --ask-pass --skip-tags="<tag>"

Note : Use necessary variables as per the requirement.
