### PR TITLE
UCI-2 - env variables for doubtnut integration

### DIFF
--- a/ansible/roles/stack-sunbird/templates/transformer.env
+++ b/ansible/roles/stack-sunbird/templates/transformer.env
@@ -83,6 +83,6 @@ SELECTED_FILE_CDN=sunbird
 #Doubtnut config
 DOUBTNUT_BASE_URL={{doubtnut_base_url | default("") }}
 DOUBTNUT_AUTH_KEY={{doubtnut_auth_key | default("") }}
-DOUBTNUT_WELCOME_MSG={{doubtnut_bot_welcome_msg | default("") }}
+DOUBTNUT_WELCOME_MSG={{doubtnut_bot_welcome_msg | default("Welcome to doubtnut") }}
 DOUBTNUT_WELCOME_VIDEO={{doubtnut_bot_video_url | default("") }}
 

--- a/ansible/roles/stack-sunbird/templates/transformer.env
+++ b/ansible/roles/stack-sunbird/templates/transformer.env
@@ -83,6 +83,6 @@ SELECTED_FILE_CDN=sunbird
 #Doubtnut config
 DOUBTNUT_BASE_URL={{doubtnut_base_url | default("") }}
 DOUBTNUT_AUTH_KEY={{doubtnut_auth_key | default("") }}
-DOUBTNUT_WELCOME_MSG={{doubtnut_bot_welcome_msg | default("Welcome to doubtnut.\nYou can ask any question by typing or clicking a image of the question and submitting it.") }}
-DOUBTNUT_WELCOME_VIDEO={{doubtnut_bot_video_url | default("http://techslides.com/demos/sample-videos/small.mp4") }}
+DOUBTNUT_WELCOME_MSG={{doubtnut_bot_welcome_msg | default("") }}
+DOUBTNUT_WELCOME_VIDEO={{doubtnut_bot_video_url | default("") }}
 

--- a/ansible/roles/stack-sunbird/templates/transformer.env
+++ b/ansible/roles/stack-sunbird/templates/transformer.env
@@ -86,3 +86,8 @@ DOUBTNUT_AUTH_KEY={{doubtnut_auth_key | default("") }}
 DOUBTNUT_WELCOME_MSG={{doubtnut_bot_welcome_msg | default("Welcome to doubtnut") }}
 DOUBTNUT_WELCOME_VIDEO={{doubtnut_bot_video_url | default("") }}
 
+#nl app url
+nlapp.userurl=${{NLAPP_USER_URL | default("")}}
+nlapp.userauth=${{NLAPP_USER_AUTH | default("")}}
+nlapp.user.xappid=${{NLAPP_USER_XAPPID | default("")}}
+

--- a/ansible/roles/stack-sunbird/templates/transformer.env
+++ b/ansible/roles/stack-sunbird/templates/transformer.env
@@ -87,7 +87,7 @@ DOUBTNUT_WELCOME_MSG={{doubtnut_bot_welcome_msg | default("Welcome to doubtnut")
 DOUBTNUT_WELCOME_VIDEO={{doubtnut_bot_video_url | default("") }}
 
 #nl app url
-nlapp.userurl=${{NLAPP_USER_URL | default("")}}
-nlapp.userauth=${{NLAPP_USER_AUTH | default("")}}
-nlapp.user.xappid=${{NLAPP_USER_XAPPID | default("")}}
+NLAPP_USER_URL={{nlapp_user_url | default("") }}
+NLAPP_USER_AUTH={{nl_user_auth | default("") }}
+NLAPP_USER_XAPPID={{nlapp_user_xappid | default("") }}
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/UCI-2" title="UCI-2" target="_blank"><img alt="Minor-Enhancement" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10310?size=medium" />UCI-2</a>  UCI Chatbot integration with Doubt solving service - version 1
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Jira ticket: [UCI-2](https://project-sunbird.atlassian.net/browse/UCI-2)

Description: We have added some new environment variables which is not releated to doutnut integration.

[UCI-2]: https://project-sunbird.atlassian.net/browse/UCI-2?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ