### PR TITLE
Updated Jenkins to latest version and JDK to OpenJDK-17

### DIFF
--- a/deploy/jenkins/jenkins-server-setup.sh
+++ b/deploy/jenkins/jenkins-server-setup.sh
@@ -9,13 +9,16 @@ echo -e "\n\e[0;32m${bold}Updating the apt repo${normal}\n"
 apt-get update
 
 echo -e "\n\e[0;32m${bold}Installating JDK8${normal}\n"
-apt-get install -y openjdk-8-jdk
+sudo apt install openjdk-17-jre
 
 echo -e "\n\e[0;32m${bold}Installating Jenkins${normal}"
-wget -q -O - https://pkg.jenkins.io/debian-stable/jenkins.io.key | apt-key add -
-apt-add-repository "deb https://pkg.jenkins.io/debian-stable binary/"
-apt-get update
-apt-get install -y jenkins=2.319.3
+curl -fsSL https://pkg.jenkins.io/debian/jenkins.io-2023.key | sudo tee \
+  /usr/share/keyrings/jenkins-keyring.asc > /dev/null
+echo deb [signed-by=/usr/share/keyrings/jenkins-keyring.asc] \
+  https://pkg.jenkins.io/debian binary/ | sudo tee \
+  /etc/apt/sources.list.d/jenkins.list > /dev/null
+sudo apt-get update
+sudo apt-get install jenkins
 
 echo -e "\n\e[0;32m${bold}Installating PIP${normal}"
 apt-get install -y python-pip


### PR DESCRIPTION
Current jenkins-server-setup.sh files installs old version of jenkins, which give error on installing plugins. Upgrading jenkins to latest version fixes the problem. 
Added latest jenkins installation instructions from official Jenkins docs.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
