### PR TITLE
Update write base path URLs list to use double quotes

### DIFF
--- a/ansible/roles/stack-sunbird/templates/assessment-service_application.conf
+++ b/ansible/roles/stack-sunbird/templates/assessment-service_application.conf
@@ -428,7 +428,7 @@ cloudstorage {
   metadata.list={{ cloudstorage_metadata_list }}
   relative_path_prefix="{{ cloudstorage_relative_path_prefix | default('CLOUD_STORAGE_BASE_PATH') }}"
   read_base_path="{{ cloudstorage_base_path }}"
-  write_base_path={{ valid_cloudstorage_base_urls }}
+  write_base_path=["{{ valid_cloudstorage_base_urls }}"]
 }
 
 #Inquiry-release-5.6.0

--- a/ansible/roles/stack-sunbird/templates/content-service_application.conf
+++ b/ansible/roles/stack-sunbird/templates/content-service_application.conf
@@ -654,5 +654,5 @@ cloudstorage {
   relative_path_prefix={{ cloudstorage_relative_path_prefix_content }}
   metadata.list={{ cloudstorage_metadata_list }}
   read_base_path="{{ cloudstorage_base_path }}"
-  write_base_path={{ valid_cloudstorage_base_urls }}
+  write_base_path=["{{ valid_cloudstorage_base_urls }}"]
 }

--- a/ansible/roles/stack-sunbird/templates/taxonomy-service_application.conf
+++ b/ansible/roles/stack-sunbird/templates/taxonomy-service_application.conf
@@ -404,5 +404,5 @@ cloudstorage {
   relative_path_prefix={{ cloudstorage_relative_path_prefix_content }}
   metadata.list={{ cloudstorage_metadata_list }}
   read_base_path="{{ cloudstorage_base_path }}"
-  write_base_path={{ valid_cloudstorage_base_urls }}
+  write_base_path=["{{ valid_cloudstorage_base_urls }}"]
 }

--- a/private_repo/ansible/inventory/dev/Core/common.yml
+++ b/private_repo/ansible/inventory/dev/Core/common.yml
@@ -277,7 +277,7 @@ cloud_artifact_storage_project: "{{ cloud_public_storage_project }}"
 # Building block vars
 cloud_storage_base_url: "{{ cloud_storage_url }}"
 cloudstorage_base_path: "{{ cloud_storage_url }}"
-valid_cloudstorage_base_urls: '["{{cloud_storage_url}}"]'
+valid_cloudstorage_base_urls: "{{cloud_storage_url}}"
 cloudstorage_relative_path_prefix: "CONTENT_STORAGE_BASE_PATH"
 
 # Provide the admin-api consumer access to all API's - The public repo restricts this for security reasons

--- a/private_repo/ansible/inventory/dev/DataPipeline/common.yml
+++ b/private_repo/ansible/inventory/dev/DataPipeline/common.yml
@@ -181,7 +181,7 @@ cloud_artifact_storage_project: "{{ cloud_public_storage_project }}"
 # Building block vars
 cloud_storage_base_url: "{{ cloud_storage_url }}"
 cloudstorage_base_path: "{{ cloud_storage_url }}"
-valid_cloudstorage_base_urls: '["{{ cloud_storage_url }}"]'
+valid_cloudstorage_base_urls: "{{ cloud_storage_url }}"
 cloudstorage_relative_path_prefix: "CONTENT_STORAGE_BASE_PATH"
 
 # The below sets the kafka topics retention time to 1 day, if you use the defaults from the public repo, it will be 7 days

--- a/private_repo/ansible/inventory/dev/KnowledgePlatform/common.yml
+++ b/private_repo/ansible/inventory/dev/KnowledgePlatform/common.yml
@@ -184,7 +184,7 @@ cloud_artifact_storage_namespace: "{{ cloud_public_storage_namespace }}"
 # Building block vars
 cloud_storage_base_url: "{{ cloud_storage_url }}"
 cloudstorage_base_path: "{{ cloud_storage_url }}"
-valid_cloudstorage_base_urls: '["{{ cloud_storage_url }}"]'
+valid_cloudstorage_base_urls: "{{ cloud_storage_url }}"
 cloudstorage_relative_path_prefix: "CONTENT_STORAGE_BASE_PATH"
 cloud_storage_pathstyle_access: true
 cloud_storage_cname_url: "{{ cloud_storage_url }}" # overide if you have seperate url for cname


### PR DESCRIPTION
By default, jinja renders list elements with single quotes which causes below error when used in configmap. The changes in this PR will give double quotes for list elements.

```
Configuration error: Configuration error[/home/sunbird/assessment-service-1.0-SNAPSHOT/config/application.conf: 431: List should have ended with ] or had a comma, instead had token: ':' (if you want ':' to be part of a string value, then double-quote it)]
```



### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Enhancement (additive changes to improve performance)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Ran Assessment, Content, Taxonomy pods and verified.

